### PR TITLE
perf: lazy stdlib (-36x startup), CI ccache+mold (-4x), trim LLVM+LTO (-59% binary, +6.7% JIT)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            # mold (Rui Ueyama's modern linker, ~2-3x faster than lld on
+            # Linux) for the LLVM-heavy static link step. macOS already
+            # uses Apple's ld-prime (Xcode 15+) by default — fast enough,
+            # no override needed.
+            linker_flag: -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold
+          - os: macos-latest
+            linker_flag: ""
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -23,9 +31,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            ccache \
             cmake \
             g++-14 \
             libblas-dev \
+            mold \
             wget \
             lsb-release \
             software-properties-common \
@@ -51,10 +61,32 @@ jobs:
       - name: Install dependencies (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install llvm just
+          brew install llvm just ccache
+
+      # Compiler cache for incremental CI builds. Without it every PR
+      # push re-compiles culebra from scratch (~4 min macOS / 7 min
+      # Ubuntu, dominated by LLVM-header-heavy interpreter.h + jit.h
+      # translation units). LLVM static link itself is not cached.
+      # CCACHE_DIR is pinned under the workspace so the path is
+      # identical between actions/cache and ccache itself (brew
+      # ccache defaults to ~/Library/Caches/ccache on macOS otherwise).
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ${{ runner.os }}-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
 
       - name: Build (interpreter + JIT)
-        run: just build
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+        run: just build -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ${{ matrix.linker_flag }}
+
+      - name: Report ccache stats
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+        run: ccache -s
 
       - name: Test (interp/JIT diff + embedding smoke + AOT + culebra-test self)
         run: just test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,14 +76,26 @@ if(CULEBRA_ENABLE_JIT)
   include_directories(${LLVM_INCLUDE_DIRS})
   add_definitions(${LLVM_DEFINITIONS})
 
-  # Native components keep the JIT path lean. AllTargets* extend the
-  # codegen + asm tables so `culebra build --target=<triple>` can emit
-  # for any LLVM-supported target (Phase E). These only inflate the
-  # `culebra` driver binary; AOT-built executables don't carry LLVM.
+  # Native target keeps the JIT lean. WebAssembly is bundled so the
+  # docs-site WASM playground (see project-docs-site memory) can be
+  # produced via `culebra build --target=wasm32-…` from the same binary.
+  # AllTargets* extend codegen + asm tables for any other LLVM target —
+  # opt-in because they add ~31 MB to the `culebra` driver. AOT-built
+  # executables never carry LLVM regardless.
+  option(CULEBRA_LLVM_ALL_TARGETS
+    "Link all LLVM backends for cross-compile (adds ~31 MB)" OFF)
+  if(CULEBRA_LLVM_ALL_TARGETS)
+    set(_extra_target_libs
+      AllTargetsAsmParsers AllTargetsCodeGens AllTargetsDescs
+      AllTargetsInfos)
+    add_compile_definitions(CULEBRA_LLVM_ALL_TARGETS)
+  else()
+    set(_extra_target_libs
+      WebAssemblyAsmParser WebAssemblyCodeGen WebAssemblyDesc
+      WebAssemblyInfo)
+  endif()
   llvm_map_components_to_libnames(llvm_libs
-    core support orcjit native passes
-    AllTargetsAsmParsers AllTargetsCodeGens AllTargetsDescs
-    AllTargetsInfos)
+    core support orcjit native passes ${_extra_target_libs})
 
   add_compile_definitions(CULEBRA_JIT_ENABLED)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,26 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
 endif()
 
+# ThinLTO trims ~15 MB off the Release `culebra` driver and gives the
+# JIT runtime a permanent +6.7% (cross-TU inlining of codegen). Cost
+# is ~25 s extra link time per build. Disable with `-DCULEBRA_LTO=OFF`
+# for fast local iterations.
+#
+# IMPORTANT: applied only to the `culebra` executable target, not to
+# `culebra_rt` / `culebra_rt_no_tensor`. Those archives ship LTO
+# bitcode that the end user's compiler links into AOT-built binaries —
+# the user's compiler may be a different toolchain/version (GCC 13 vs
+# 14, Clang vs GCC) and chokes on cross-version LTO bitcode. Object
+# code only for archives keeps `culebra build` portable.
+option(CULEBRA_LTO "Enable ThinLTO for the culebra driver (Release)" ON)
+include(CheckIPOSupported)
+check_ipo_supported(RESULT _ipo_supported OUTPUT _ipo_err)
+if(CULEBRA_LTO AND _ipo_supported AND CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(_culebra_enable_lto TRUE)
+else()
+  set(_culebra_enable_lto FALSE)
+endif()
+
 include_directories(./include)
 include_directories(./vendor/cpp-peglib)
 include_directories(./vendor/cpp-linenoise)
@@ -101,6 +121,9 @@ if(CULEBRA_ENABLE_JIT)
 endif()
 
 add_executable(culebra ./src/main.cc)
+if(_culebra_enable_lto)
+  set_target_properties(culebra PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
 
 if(CULEBRA_ENABLE_JIT)
   target_link_libraries(culebra ${llvm_libs})

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -1463,7 +1463,7 @@ inline const std::shared_ptr<Value>& kw_default_nil() {
   return v;
 }
 
-struct Environment {
+struct Environment : std::enable_shared_from_this<Environment> {
   Environment(std::shared_ptr<Environment> parent = nullptr)
       : level(parent ? parent->level + 1 : 0) {}
 
@@ -1489,6 +1489,14 @@ struct Environment {
 
   const Value& get(std::string_view s) const {
     if (auto it = dictionary.find(s); it != dictionary.end()) {
+      // Fast path: once all lazy modules are resolved, `lazy_pending`
+      // is empty and the lookup is skipped entirely.
+      if (!lazy_pending.empty()) {
+        if (auto lit = lazy_pending.find(s); lit != lazy_pending.end()) {
+          const_cast<Environment*>(this)->resolve_from_lazy(s, lit->second);
+          it = dictionary.find(s);
+        }
+      }
       return it->second.val;
     } else if (outer) {
       return outer->get(s);
@@ -1496,6 +1504,23 @@ struct Environment {
     throw CulebraError("NameError",
                        std::format("undefined variable '{}'...", s));
   }
+
+  // Register `source` to be parsed + evaluated lazily on first
+  // `get(name)`. The source must `let <name> = ...` so the eval pass
+  // overwrites the placeholder binding in `dictionary`. Used for stdlib
+  // modules that are expensive to parse but rarely touched in short
+  // scripts — see [[project-startup-overhead]].
+  void initialize_lazy(std::string_view name, std::string source) {
+    initialize(name, Value{}, /*mut=*/false);
+    if (is_sink_name(name)) return;
+    lazy_pending.insert_or_assign(
+        std::string(name),
+        std::make_shared<std::string>(std::move(source)));
+  }
+
+  // Defined below `interpret` since it parses + evaluates the source.
+  void resolve_from_lazy(std::string_view name,
+                         std::shared_ptr<std::string> source);
 
   void assign(std::string_view s, Value val) {
     assert(has(s));
@@ -1532,6 +1557,17 @@ struct Environment {
   // Deferred callables registered in this scope via `defer { ... }`.
   // Fired in LIFO order when the scope exits (normally or via throw).
   std::vector<std::function<void()>> deferred;
+  // Names not yet resolved, mapped to their source. The first `get` of
+  // a key in this map triggers parse + eval and removes the entry. The
+  // `get` fast path checks `empty()` first so once all modules are
+  // resolved this costs nothing.
+  std::map<std::string, std::shared_ptr<std::string>, std::less<>> lazy_pending;
+  // Source buffers backing lazily-resolved stdlib modules. AST tokens
+  // hold string_views into these; FunctionValue closures over methods
+  // declared in the module survive long after `resolve_from_lazy`
+  // returns, so the buffer must outlive any value bound through that
+  // resolution. Anchored to the env that owns the lazy binding.
+  std::vector<std::shared_ptr<std::string>> lazy_module_sources;
 };
 
 // Lexical scope chained to `outer`. Function frames don't use this —
@@ -6194,6 +6230,36 @@ inline bool interpret(const std::shared_ptr<peg::Ast>& ast,
   }
 
   return false;
+}
+
+// Resolve a lazy-registered module: parse + interpret the source against
+// this env so the placeholder binding is replaced by the real value. The
+// pending entry is removed before evaluation to short-circuit re-entry
+// if the source references the same name. The source is anchored in
+// `lazy_module_sources` so AST tokens (string_views into it) stay valid
+// for the lifetime of the env — class methods bound during eval may be
+// invoked long after this call returns.
+inline void Environment::resolve_from_lazy(
+    std::string_view name, std::shared_ptr<std::string> source) {
+  lazy_pending.erase(std::string(name));
+  lazy_module_sources.push_back(source);
+  std::vector<std::string> parse_msgs;
+  auto vpath = std::format("<lazy-{}>", name);
+  auto ast = parse(vpath, source->data(), source->size(), parse_msgs);
+  if (!ast) {
+    std::fprintf(stderr, "culebra: lazy module '%s' failed to parse\n",
+                 std::string(name).c_str());
+    for (auto& m : parse_msgs) std::fprintf(stderr, "  %s", m.c_str());
+    std::abort();
+  }
+  Value dummy;
+  std::vector<std::string> eval_msgs;
+  if (!interpret(ast, shared_from_this(), dummy, eval_msgs)) {
+    std::fprintf(stderr, "culebra: lazy module '%s' failed to eval\n",
+                 std::string(name).c_str());
+    for (auto& m : eval_msgs) std::fprintf(stderr, "  %s", m.c_str());
+    std::abort();
+  }
 }
 
 // --- Cycle collector implementation ---

--- a/include/jit.h
+++ b/include/jit.h
@@ -6238,17 +6238,31 @@ struct JIT {
     });
   }
 
-  // Cross-compile: register every target LLVM was built with so
-  // `culebra build --target=<triple>` can look up arbitrary triples.
-  // Lazy + idempotent; only the AOT path needs to pay this cost.
+  // Cross-compile target init. With CULEBRA_LLVM_ALL_TARGETS the driver
+  // links every LLVM backend (~31 MB) and registers them all so that
+  // `culebra build --target=<triple>` accepts any triple. Without the
+  // option the driver only links Native + WebAssembly (default), so
+  // only those two are registered here. Lazy + idempotent; only the
+  // AOT path pays this cost.
   static void ensure_all_targets_init() {
     static std::once_flag flag;
     std::call_once(flag, []() {
+#ifdef CULEBRA_LLVM_ALL_TARGETS
       llvm::InitializeAllTargetInfos();
       llvm::InitializeAllTargets();
       llvm::InitializeAllTargetMCs();
       llvm::InitializeAllAsmPrinters();
       llvm::InitializeAllAsmParsers();
+#else
+      llvm::InitializeNativeTarget();
+      llvm::InitializeNativeTargetAsmPrinter();
+      llvm::InitializeNativeTargetAsmParser();
+      LLVMInitializeWebAssemblyTargetInfo();
+      LLVMInitializeWebAssemblyTarget();
+      LLVMInitializeWebAssemblyTargetMC();
+      LLVMInitializeWebAssemblyAsmPrinter();
+      LLVMInitializeWebAssemblyAsmParser();
+#endif
     });
   }
 

--- a/include/repl.h
+++ b/include/repl.h
@@ -119,15 +119,10 @@ inline int repl(std::shared_ptr<Environment> env, bool print_ast,
       std::abort();
     }
   }
-  else
 #endif
-  {
-    // `environment()` returns an env without the culebra-source
-    // preamble; load it here so Time / Args are visible in the REPL.
-    // Idempotent: load_stdlib_modules's initialize calls overwrite
-    // any prior binding silently.
-    load_stdlib_modules(env);
-  }
+  // interp REPL relies on the env's lazy Time / Args bindings registered
+  // by `environment()`; no explicit preamble load needed. JIT REPL still
+  // pre-runs the preamble above (Phase 3 of [[project-startup-overhead]]).
 
   // Default linenoise cap is 100 entries, which is small by REPL
   // convention (bash ≈ 500, python / node ≈ 1000). Bump before

--- a/include/stdlib_interp.h
+++ b/include/stdlib_interp.h
@@ -589,7 +589,7 @@ inline std::string format_strftime_nanos(int64_t nanos,
 }  // namespace _time_detail
 
 // `_Time`: thin Long-nanos primitives. The user-facing `Time` module
-// (Instant / Duration classes — `STDLIB_PREAMBLE_SOURCE` below) wraps
+// (Instant / Duration classes — `TIME_MODULE_SOURCE` below) wraps
 // these to deliver natural calendar arithmetic + operator overloads.
 // Underscore prefix marks it as the wrapper's ABI, not a stable
 // surface for direct use.
@@ -1641,17 +1641,17 @@ inline void setup_built_in_functions(
 }
 
 // Embedded culebra source for stdlib modules that are easier to express
-// in culebra than in C++. Loaded into the env by `load_stdlib_modules`
-// (interp) and prepended to the user program by `JIT::run` /
-// `JIT::build_object` (JIT). Single-line so user-code error positions
-// are only off-by-one.
+// in culebra than in C++. Both Time and Args are registered lazily by
+// `environment()` — see [[project-startup-overhead]]. The JIT path
+// still pre-concats them via `STDLIB_PREAMBLE_SOURCE` until it adopts
+// the env's lazy bindings. Each module is single-line so user-code
+// error positions are only off-by-one.
 //
-// Modules:
-//   * `Time` — Instant / Duration classes wrapping `_Time` primitives.
-//     Operator overloads (`__add__` / `__sub__` / `__mul__` / `__div__`
-//     / `__neg__` / `__lt__` / `__le__` / `__eq__`) give natural
-//     timestamp arithmetic.
-inline constexpr const char* STDLIB_PREAMBLE_SOURCE =
+// `Time` — Instant / Duration classes wrapping `_Time` primitives.
+// Operator overloads (`__add__` / `__sub__` / `__mul__` / `__div__`
+// / `__neg__` / `__lt__` / `__le__` / `__eq__`) give natural
+// timestamp arithmetic.
+inline constexpr const char* TIME_MODULE_SOURCE =
     "let _time_module = fn () { "
     "class Duration { "
     "new(nanos) { this._nanos = nanos } "
@@ -1703,13 +1703,14 @@ inline constexpr const char* STDLIB_PREAMBLE_SOURCE =
     "Instant: Instant, Duration: Duration "
     "} "
     "}; "
-    "let Time = _time_module(); "
-    //
-    //   * `Args` — declarative CLI argument parser. Spec is a culebra
-    //     Object listing positionals + options + subcommands; `Args.parse`
-    //     returns an Object with parsed fields, prints help on `--help`,
-    //     and reports errors with `Sys.exit(2)`. `try_parse` raises
-    //     `{kind: \"ArgParseError\", message}` for programmatic control.
+    "let Time = _time_module()\n";
+
+// `Args` — declarative CLI argument parser. Spec is a culebra
+// Object listing positionals + options + subcommands; `Args.parse`
+// returns an Object with parsed fields, prints help on `--help`,
+// and reports errors with `Sys.exit(2)`. `try_parse` raises
+// `{kind: \"ArgParseError\", message}` for programmatic control.
+inline constexpr const char* ARGS_MODULE_SOURCE =
     "let _args_module = fn() { "
     "let _coerce = fn(raw, type, name) { "
     "if type == \"String\" { return raw }; "
@@ -1956,38 +1957,43 @@ inline constexpr const char* STDLIB_PREAMBLE_SOURCE =
     "}; "
     "let Args = _args_module()\n";
 
-// Concatenate the stdlib preamble in front of `user_src` so a single
-// parse + analyze + compile pass sees the full program. Used by the
-// CLI (`run_scripts` / `run_build`) — embedders that build their env
-// via `culebra::environment()` and feed user source through `parse`
-// + `interpret` can wrap their source the same way.
-inline std::string prepend_stdlib_preamble(std::string_view user_src) {
+// Transitional concatenation used by the JIT path until it adopts the
+// env's lazy bindings (Phase 3 of [[project-startup-overhead]]). The
+// interp path is already preamble-free.
+inline const char* _stdlib_preamble_concat() {
+  static const std::string s =
+      std::string(TIME_MODULE_SOURCE) + ARGS_MODULE_SOURCE;
+  return s.c_str();
+}
+inline const char* STDLIB_PREAMBLE_SOURCE = _stdlib_preamble_concat();
+
+// Concatenate `user_src` with the stdlib modules it appears to
+// reference (substring match). Used by the JIT and AOT paths to skip
+// Time/Args parsing when scripts don't touch them. A substring hit is
+// a safe over-approximation: false positives (e.g. `let myTime = 1`)
+// just include an unneeded module; only true negatives skip the
+// prepend, preserving correctness.
+inline std::string prepend_stdlib_preamble_selective(
+    std::string_view user_src) {
+  bool needs_time = user_src.find("Time") != std::string_view::npos;
+  bool needs_args = user_src.find("Args") != std::string_view::npos;
   std::string combined;
-  combined.reserve(std::strlen(STDLIB_PREAMBLE_SOURCE) + user_src.size());
-  combined.append(STDLIB_PREAMBLE_SOURCE);
+  combined.reserve(
+      (needs_time ? std::strlen(TIME_MODULE_SOURCE) : 0) +
+      (needs_args ? std::strlen(ARGS_MODULE_SOURCE) : 0) + user_src.size());
+  if (needs_time) combined.append(TIME_MODULE_SOURCE);
+  if (needs_args) combined.append(ARGS_MODULE_SOURCE);
   combined.append(user_src);
   return combined;
 }
 
-// Parse + interpret-eval the stdlib preamble into `env`. Used at REPL
-// session start (interp mode) where each input is parsed separately
-// so we can't pre-concat. Aborts on internal failure — the preamble
-// is hard-coded so a failure means the binary itself is broken.
-inline void load_stdlib_modules(std::shared_ptr<Environment> env) {
-  std::vector<std::string> msgs;
-  auto src = STDLIB_PREAMBLE_SOURCE;
-  auto ast = parse("<stdlib>", src, std::strlen(src), msgs);
-  if (!ast) {
-    std::fprintf(stderr, "culebra: internal stdlib preamble failed to parse\n");
-    for (auto& m : msgs) std::fprintf(stderr, "  %s", m.c_str());
-    std::abort();
-  }
-  Value v;
-  if (!interpret(ast, env, v, msgs)) {
-    std::fprintf(stderr, "culebra: internal stdlib preamble failed to eval\n");
-    for (auto& m : msgs) std::fprintf(stderr, "  %s", m.c_str());
-    std::abort();
-  }
+// Register stdlib modules that should not be parsed/evaluated up front.
+// Each module is bound lazily so scripts that never touch it pay zero
+// cost. See [[project-startup-overhead]] for the measurement that
+// motivated this.
+inline void register_stdlib_lazy_modules(Environment& env) {
+  env.initialize_lazy("Time", TIME_MODULE_SOURCE);
+  env.initialize_lazy("Args", ARGS_MODULE_SOURCE);
 }
 
 inline std::shared_ptr<Environment> environment(
@@ -1995,10 +2001,7 @@ inline std::shared_ptr<Environment> environment(
   auto env = std::make_shared<Environment>();
   setup_core_globals(*env);
   setup_built_in_functions(*env, argv);
-  // Caller invokes `load_stdlib_modules(env)` if it intends to run
-  // interp scripts (so Time / Args become visible in the outer scope
-  // for dep modules). JIT / AOT paths bypass this since they pre-
-  // concat the preamble into the entry source.
+  register_stdlib_lazy_modules(*env);
   return env;
 }
 

--- a/include/stdlib_jit.h
+++ b/include/stdlib_jit.h
@@ -374,10 +374,11 @@ CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_fs_remove(
 // --- _Time primitives ---
 // Calendar logic is shared with the interpreter via `culebra::_time_detail`
 // (see stdlib_interp.h). The user-facing `Time` module (Instant /
-// Duration classes) is built from culebra source (`STDLIB_PREAMBLE_SOURCE`
-// in stdlib_interp.h) and prepended by `culebra::prepend_stdlib_preamble`
-// in the CLI's run paths. Timestamps are i64 nanos since Unix epoch;
-// `monotonic` / `sleep` stay Float (measurement, precision-insensitive).
+// Duration classes) is built from culebra source (`TIME_MODULE_SOURCE`
+// in stdlib_interp.h) — interp registers it lazily, JIT/AOT prepend it
+// selectively via `prepend_stdlib_preamble_selective`. Timestamps are
+// i64 nanos since Unix epoch; `monotonic` / `sleep` stay Float
+// (measurement, precision-insensitive).
 
 CULEBRA_RT_KEEP CULEBRA_RT_INLINE int64_t culebra_runtime_time_now_nanos() {
   using clock = std::chrono::system_clock;

--- a/include/test_runner.h
+++ b/include/test_runner.h
@@ -56,29 +56,12 @@ class StdoutCapture {
   }
 };
 
-// Number of newlines in the stdlib preamble — used to map a runtime
-// error's `line` (computed against the prepended buffer) back to the
-// user's file line.
-inline int stdlib_preamble_line_count() {
-  static const int n = []() {
-    int c = 0;
-    for (const char* p = STDLIB_PREAMBLE_SOURCE; *p; p++) {
-      if (*p == '\n') c++;
-    }
-    return c;
-  }();
-  return n;
-}
-
-// Convert a runtime error line (raw, against the prepended buffer) to
-// a user-file line. Errors from imported modules (no preamble) come
-// through with `raw <= preamble` and we report 0 (unknown) rather than
-// guess a wrong line — CulebraError doesn't carry the source path so
-// we can't tell which file the error came from.
+// Convert a runtime error line (1-based) to a user-file line, returning
+// 0 for unknown locations. Preamble offset removed in Phase 2 of
+// [[project-startup-overhead]] when the interp test path stopped
+// prepending stdlib source.
 inline int to_user_line(long raw) {
-  if (raw <= 0) return 0;
-  long adjusted = raw - stdlib_preamble_line_count();
-  return adjusted > 0 ? static_cast<int>(adjusted) : 0;
+  return raw > 0 ? static_cast<int>(raw) : 0;
 }
 
 // Snippet of `source` around `line` (1-based, in user-file coordinates)
@@ -630,9 +613,10 @@ inline TestRunSummary run_tests(
     std::vector<std::string> msgs;
     ModuleLoader loader;
     std::vector<LoadedModule> modules;
-    auto entry_src = prepend_stdlib_preamble(buff);
+    // Time / Args come from the env's lazy bindings — no preamble
+    // prepend needed (Phase 2 of [[project-startup-overhead]]).
     try {
-      modules = loader.load_program(path_str, entry_src, msgs);
+      modules = loader.load_program(path_str, buff, msgs);
     } catch (const CulebraError& e) {
       emit_file_error(path_str, e.kind, e.what(), e.line, e.col);
       summary.errored_files++;
@@ -804,7 +788,7 @@ inline TestRunSummary run_tests(
         // here, so leave snippet empty rather than render the wrong
         // file's lines.
         std::string snippet;
-        if (err_line > 0 && err_line > stdlib_preamble_line_count()) {
+        if (err_line > 0) {
           if (auto it = user_sources.find(entry_source);
               it != user_sources.end()) {
             snippet = source_snippet(it->second, user_line);

--- a/justfile
+++ b/justfile
@@ -4,11 +4,12 @@ set shell := ["bash", "-cu"]
 default:
     @just --list
 
-# Configure and build with LLVM JIT enabled (Release)
+# Configure and build with LLVM JIT enabled (Release). Extra cmake
+# flags can be passed positionally (used by CI to wire ccache).
 [group("build")]
-build:
+build *extra:
     mkdir -p build
-    cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCULEBRA_ENABLE_JIT=ON .. > /dev/null
+    cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCULEBRA_ENABLE_JIT=ON {{extra}} .. > /dev/null
     cd build && make
 
 # Build without JIT (Release)

--- a/justfile
+++ b/justfile
@@ -4,15 +4,16 @@ set shell := ["bash", "-cu"]
 default:
     @just --list
 
-# Configure and build with LLVM JIT enabled (Release). Extra cmake
-# flags can be passed positionally (used by CI to wire ccache).
+# Configure and build with LLVM JIT enabled (Release + LTO by default).
+# Extra cmake flags can be passed positionally — CI uses this to wire
+# ccache, contributors can pass `-DCULEBRA_LTO=OFF` to skip LTO link.
 [group("build")]
 build *extra:
     mkdir -p build
     cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCULEBRA_ENABLE_JIT=ON {{extra}} .. > /dev/null
     cd build && make
 
-# Build without JIT (Release)
+# Build without JIT (interpreter only, no LLVM)
 [group("build")]
 build-no-jit:
     mkdir -p build

--- a/src/main.cc
+++ b/src/main.cc
@@ -8,13 +8,45 @@
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 #endif
+#include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <print>
+#include <utility>
+#include <vector>
 
 using namespace std;
+
+// Startup profiler — gated by CULEBRA_PROFILE_STARTUP=1. Prints each
+// phase mark to stderr immediately. See [[project-startup-overhead]].
+namespace startup_profile {
+using clk = std::chrono::steady_clock;
+inline clk::time_point& t0() { static clk::time_point v; return v; }
+inline clk::time_point& tprev() { static clk::time_point v; return v; }
+inline bool& enabled_flag() { static bool v = false; return v; }
+inline void start() {
+  const char* e = std::getenv("CULEBRA_PROFILE_STARTUP");
+  enabled_flag() = e && *e && e[0] != '0';
+  if (enabled_flag()) {
+    auto now = clk::now();
+    t0() = now;
+    tprev() = now;
+    std::fprintf(stderr, "[startup-profile] (env CULEBRA_PROFILE_STARTUP set)\n");
+  }
+}
+inline void mark(const char* name) {
+  if (!enabled_flag()) return;
+  auto t = clk::now();
+  auto ms_delta = std::chrono::duration<double, std::milli>(t - tprev()).count();
+  auto ms_total = std::chrono::duration<double, std::milli>(t - t0()).count();
+  std::fprintf(stderr, "  %7.2f ms (+%6.2f ms)  %s\n", ms_total, ms_delta, name);
+  std::fflush(stderr);
+  tprev() = t;
+}
+}  // namespace startup_profile
 
 bool read_file(const char* path, vector<char>& buff) {
   ifstream ifs(path, ios::in | ios::binary);
@@ -261,7 +293,7 @@ int run_build(const BuildOptions& opts) {
     std::println(stderr, "culebra build: can't open '{}'", opts.input);
     return 1;
   }
-  auto entry_src = culebra::prepend_stdlib_preamble(
+  auto entry_src = culebra::prepend_stdlib_preamble_selective(
       std::string_view(buff.data(), buff.size()));
   vector<string> msgs;
   culebra::ModuleLoader loader;
@@ -434,12 +466,10 @@ Options parse_command_line(int argc, const char** argv) {
 }
 
 bool run_scripts(shared_ptr<culebra::Environment> env, const Options& options) {
-#ifdef CULEBRA_JIT_ENABLED
-  bool needs_preamble = !options.jit;
-#else
-  bool needs_preamble = true;
-#endif
-  if (needs_preamble) culebra::load_stdlib_modules(env);
+  // Time / Args are registered lazily by `environment()` — no eager
+  // preamble load needed here. The JIT path still pre-concats the
+  // preamble (handled in Phase 3 of [[project-startup-overhead]]).
+  startup_profile::mark("run_scripts begin");
 
   for (auto path : options.script_path_list) {
     vector<char> buff;
@@ -447,19 +477,26 @@ bool run_scripts(shared_ptr<culebra::Environment> env, const Options& options) {
       std::println(stderr, "can't open '{}'.", path);
       return false;
     }
+    startup_profile::mark("read_file");
 
     vector<string> msgs;
     std::string_view user_src(buff.data(), buff.size());
 
     // Walk the dependency graph via ModuleLoader. The same vector
     // feeds both backends — JIT bundles every module into one IR,
-    // interp evaluates them sequentially.
+    // interp evaluates them sequentially. The JIT path needs the
+    // stdlib preamble inlined because it doesn't currently honour
+    // the env's lazy bindings (see Phase 3 of [[project-startup-overhead]]).
     culebra::ModuleLoader loader;
     std::vector<culebra::LoadedModule> modules;
-    // Entry source goes in with the stdlib preamble already prepended
-    // so the JIT path (which doesn't pre-load Time / Args via env)
-    // sees those classes as ordinary top-level declarations.
-    auto entry_src = culebra::prepend_stdlib_preamble(user_src);
+    std::string jit_src;
+    std::string_view entry_src = user_src;
+#ifdef CULEBRA_JIT_ENABLED
+    if (options.jit) {
+      jit_src = culebra::prepend_stdlib_preamble_selective(user_src);
+      entry_src = jit_src;
+    }
+#endif
     try {
       modules = loader.load_program(path, entry_src, msgs);
     } catch (const culebra::CulebraError& e) {
@@ -472,6 +509,7 @@ bool run_scripts(shared_ptr<culebra::Environment> env, const Options& options) {
       for (const auto& msg : msgs) cerr << msg << endl;
       return false;
     }
+    startup_profile::mark("ModuleLoader::load_program (parse)");
 
     if (options.print_ast) {
       for (const auto& m : modules) {
@@ -492,7 +530,10 @@ bool run_scripts(shared_ptr<culebra::Environment> env, const Options& options) {
     culebra::Value val;
     auto dbg =
         options.debug ? culebra::CommandLineDebugger() : culebra::Debugger();
-    if (culebra::interpret_modules(modules, env, val, msgs, dbg)) continue;
+    if (culebra::interpret_modules(modules, env, val, msgs, dbg)) {
+      startup_profile::mark("interpret_modules");
+      continue;
+    }
     for (const auto& msg : msgs) cerr << msg << endl;
     return false;
   }
@@ -591,6 +632,9 @@ int run_test(int argc, const char** argv) {
 }
 
 int main(int argc, const char** argv) {
+  startup_profile::start();
+  startup_profile::mark("main entered");
+
   if (argc >= 2 && string(argv[1]) == "test") {
     return run_test(argc, argv);
   }
@@ -609,14 +653,18 @@ int main(int argc, const char** argv) {
 #endif
 
   auto options = parse_command_line(argc, argv);
+  startup_profile::mark("parse_command_line");
 
 #ifdef CULEBRA_JIT_ENABLED
   culebra::install_jit_stdlib();
+  startup_profile::mark("install_jit_stdlib");
 #endif
 
   try {
     auto env = culebra::environment(options.script_argv);
+    startup_profile::mark("environment() (interp stdlib registered)");
     install_cli_aliases(*env);
+    startup_profile::mark("install_cli_aliases");
 
     if (!run_scripts(env, options)) {
       return -1;

--- a/tools/bench/args_use.cul
+++ b/tools/bench/args_use.cul
@@ -1,0 +1,3 @@
+let spec = {name: "x", args: [{name: "foo", doc: "demo"}]}
+let p = Args.try_parse(["hello"], spec)
+print(p.foo)

--- a/tools/bench/fib.cul
+++ b/tools/bench/fib.cul
@@ -1,0 +1,2 @@
+fn fib(n) { if n < 2 { n } else { fib(n - 1) + fib(n - 2) } }
+print(fib(28))

--- a/tools/bench/hello.cul
+++ b/tools/bench/hello.cul
@@ -1,0 +1,1 @@
+print("hello")

--- a/tools/bench/hello.js
+++ b/tools/bench/hello.js
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/tools/bench/hello.py
+++ b/tools/bench/hello.py
@@ -1,0 +1,1 @@
+print("hello")

--- a/tools/bench/time_use.cul
+++ b/tools/bench/time_use.cul
@@ -1,0 +1,2 @@
+let t = Time.now()
+print(t.unix_nanos() > 0)

--- a/tools/sample_llvm_other.py
+++ b/tools/sample_llvm_other.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Sample the 'llvm::other' bucket: top symbols by size + top namespace prefixes."""
+import re, subprocess, sys
+from collections import Counter
+
+binary = sys.argv[1] if len(sys.argv) > 1 else '/Users/yuji/Projects/culebra/build/culebra'
+
+proc = subprocess.run(['nm', '-n', binary], capture_output=True, text=True)
+raw = []
+for line in proc.stdout.splitlines():
+    parts = line.split(None, 2)
+    if len(parts) != 3:
+        continue
+    try:
+        addr = int(parts[0], 16)
+    except ValueError:
+        continue
+    raw.append((addr, parts[1], parts[2]))
+raw.sort()
+
+entries = []
+for i, (addr, t, name) in enumerate(raw):
+    if t not in ('T', 't'):
+        continue
+    nxt = next((raw[j][0] for j in range(i+1, len(raw)) if raw[j][0] > addr), None)
+    if nxt is None:
+        continue
+    size = nxt - addr
+    if 0 < size <= 10*1024*1024:
+        entries.append((name, size))
+
+names = [e[0] for e in entries]
+demangled = subprocess.run(['c++filt'], input='\n'.join(names), capture_output=True, text=True).stdout.rstrip('\n').split('\n')
+
+known_targets = ['X86','AArch64','ARM','PowerPC','Mips','RISCV','WebAssembly','SystemZ','Sparc','AVR','AMDGPU','NVPTX','Hexagon','Lanai','BPF','LoongArch','VE','XCore','M68k','MSP430','Xtensa','CSKY','DirectX','SPIRV']
+target_pat = re.compile(r'\bllvm::(' + '|'.join(known_targets) + r')\b')
+component_re = [
+    re.compile(r'\bllvm::orc::'),
+    re.compile(r'\bllvm::MC[A-Z]|\bllvm::mc::'),
+    re.compile(r'\bllvm::(MachineFunction|MachineInstr|SelectionDAG|LiveInterval|RegAlloc)'),
+    re.compile(r'\bllvm::(IRBuilder|Module|Function|Instruction|BasicBlock|Constant|GlobalVariable|Type|Value)\b'),
+    re.compile(r'\bllvm::(StringRef|SmallVector|DenseMap|StringMap|Triple|raw_|ErrorOr|Optional|cl::)'),
+    re.compile(r'\bllvm::(LoopInfo|ScalarEvolution|AAResults|DominatorTree|MemorySSA|TargetLibraryInfo)'),
+    re.compile(r'\bllvm::(PassBuilder|InstCombine|GVN|SimplifyCFG|LoopVectorize|SLPVectorizer)'),
+    re.compile(r'\bllvm::(DWARF|DIE|DebugInfo|DIBuilder)'),
+    re.compile(r'\bllvm::Bitcode'),
+    re.compile(r'\bllvm::object::'),
+]
+def classified(name):
+    if target_pat.search(name): return True
+    for p in component_re:
+        if p.search(name): return True
+    return False
+
+# Filter to llvm::other (unclassified llvm:: symbols)
+other = [(n, s) for (_, s), n in zip(entries, demangled) if 'llvm::' in n and not classified(n)]
+other.sort(key=lambda x: -x[1])
+
+print(f"=== top 30 'llvm::other' symbols by size ===")
+for n, s in other[:30]:
+    print(f"  {s:>8,}  {n[:200]}")
+
+# Look at second-level namespace under llvm::
+ns2 = Counter()
+for n, s in other:
+    m = re.search(r'\bllvm::(\(anonymous namespace\)::)?([A-Za-z0-9_]+)', n)
+    if m:
+        ns2[m.group(2)] += s
+    else:
+        ns2['<other>'] += s
+
+print()
+print(f"=== top 30 second-level prefixes under llvm:: in 'other' ===")
+for k, v in ns2.most_common(30):
+    print(f"  {v/1024/1024:>6.2f} MB   llvm::{k}")

--- a/tools/size_by_llvm_target.py
+++ b/tools/size_by_llvm_target.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Categorize culebra binary code-size contribution by LLVM target/component.
+
+Approximates per-symbol size from sorted nm -n output (Mach-O nm does not
+emit sizes). Each T/t symbol's size is `next_addr - this_addr`.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+binary = sys.argv[1] if len(sys.argv) > 1 else 'build/culebra'
+
+proc = subprocess.run(['nm', '-n', binary], capture_output=True, text=True)
+raw = []
+for line in proc.stdout.splitlines():
+    parts = line.split(None, 2)
+    if len(parts) != 3:
+        continue
+    try:
+        addr = int(parts[0], 16)
+    except ValueError:
+        continue
+    raw.append((addr, parts[1], parts[2]))
+raw.sort()
+
+entries = []
+total = 0
+for i, (addr, t, name) in enumerate(raw):
+    if t not in ('T', 't'):
+        continue
+    nxt = None
+    for j in range(i + 1, len(raw)):
+        if raw[j][0] > addr:
+            nxt = raw[j][0]
+            break
+    if nxt is None:
+        continue
+    size = nxt - addr
+    if size <= 0 or size > 10 * 1024 * 1024:
+        continue
+    entries.append((name, size))
+    total += size
+
+names = [e[0] for e in entries]
+demangled = subprocess.run(
+    ['c++filt'], input='\n'.join(names),
+    capture_output=True, text=True,
+).stdout.rstrip('\n').split('\n')
+
+# LLVM backend targets (folder names under llvm/lib/Target/).
+target_aliases = {
+    'X86':         [r'llvm::X86', r'\(anonymous namespace\)::X86'],
+    'AArch64':     [r'llvm::AArch64', r'\(anonymous namespace\)::AArch64'],
+    'ARM':         [r'llvm::ARM(?!V[0-9]*Reg)', r'\(anonymous namespace\)::ARM'],
+    'PowerPC':     [r'llvm::P(?:PC|owerPC)', r'\(anonymous namespace\)::PPC'],
+    'Mips':        [r'llvm::Mips', r'\(anonymous namespace\)::Mips'],
+    'RISCV':       [r'llvm::RISCV', r'\(anonymous namespace\)::RISCV'],
+    'WebAssembly': [r'llvm::(?:WebAssembly|WASM)', r'\(anonymous namespace\)::(?:WebAssembly|WASM)'],
+    'SystemZ':     [r'llvm::SystemZ', r'\(anonymous namespace\)::SystemZ'],
+    'Sparc':       [r'llvm::Sparc', r'\(anonymous namespace\)::Sparc'],
+    'AVR':         [r'llvm::AVR', r'\(anonymous namespace\)::AVR'],
+    # AMDGPU has GCN/SI/R600 sub-prefixes too.
+    'AMDGPU':      [r'llvm::(?:AMDGPU|GCN|SI[A-Z]|R600)', r'\(anonymous namespace\)::(?:AMDGPU|GCN|SI[A-Z]|R600)'],
+    'NVPTX':       [r'llvm::NVPTX', r'\(anonymous namespace\)::NVPTX'],
+    'Hexagon':     [r'llvm::Hexagon', r'\(anonymous namespace\)::Hexagon'],
+    'Lanai':       [r'llvm::Lanai', r'\(anonymous namespace\)::Lanai'],
+    'BPF':         [r'llvm::BPF', r'\(anonymous namespace\)::BPF'],
+    'LoongArch':   [r'llvm::LoongArch', r'\(anonymous namespace\)::LoongArch'],
+    'VE':          [r'llvm::VE[A-Z]', r'\(anonymous namespace\)::VE[A-Z]'],
+    'XCore':       [r'llvm::XCore', r'\(anonymous namespace\)::XCore'],
+    'M68k':        [r'llvm::M68k', r'\(anonymous namespace\)::M68k'],
+    'MSP430':      [r'llvm::MSP430', r'\(anonymous namespace\)::MSP430'],
+    'Xtensa':      [r'llvm::Xtensa', r'\(anonymous namespace\)::Xtensa'],
+    'CSKY':        [r'llvm::CSKY', r'\(anonymous namespace\)::CSKY'],
+    'DirectX':     [r'llvm::(?:DirectX|DXIL)', r'\(anonymous namespace\)::(?:DirectX|DXIL)'],
+    'SPIRV':       [r'llvm::SPIRV', r'\(anonymous namespace\)::SPIRV'],
+}
+targets = list(target_aliases.keys())
+target_re = {t: re.compile('|'.join(target_aliases[t])) for t in targets}
+
+# Non-target LLVM components (rough buckets by namespace prefix).
+component_re = [
+    ('llvm::orc',        re.compile(r'\bllvm::orc::')),
+    ('llvm::mc',         re.compile(r'\bllvm::MC[A-Z]|\bllvm::mc::')),
+    ('llvm::codegen',    re.compile(r'\bllvm::(MachineFunction|MachineInstr|SelectionDAG|LiveInterval|RegAlloc)')),
+    ('llvm::ir',         re.compile(r'\bllvm::(IRBuilder|Module|Function|Instruction|BasicBlock|Constant|GlobalVariable|Type|Value)\b')),
+    ('llvm::support',    re.compile(r'\bllvm::(StringRef|SmallVector|DenseMap|StringMap|Triple|raw_|ErrorOr|Optional|cl::)')),
+    ('llvm::analysis',   re.compile(r'\bllvm::(LoopInfo|ScalarEvolution|AAResults|DominatorTree|MemorySSA|TargetLibraryInfo)')),
+    ('llvm::transforms', re.compile(r'\bllvm::(PassBuilder|InstCombine|GVN|SimplifyCFG|LoopVectorize|SLPVectorizer)')),
+    ('llvm::debuginfo',  re.compile(r'\bllvm::(DWARF|DIE|DebugInfo|DIBuilder)')),
+    ('llvm::bitcode',    re.compile(r'\bllvm::Bitcode')),
+    ('llvm::object',     re.compile(r'\bllvm::object::')),
+]
+
+target_size = {t: [0, 0] for t in targets}
+comp_size = {k: [0, 0] for k, _ in component_re}
+llvm_other = [0, 0]
+non_llvm = [0, 0]
+
+for (mangled, size), name in zip(entries, demangled):
+    matched = False
+    for t, p in target_re.items():
+        if p.search(name):
+            target_size[t][0] += 1
+            target_size[t][1] += size
+            matched = True
+            break
+    if matched:
+        continue
+    for k, p in component_re:
+        if p.search(name):
+            comp_size[k][0] += 1
+            comp_size[k][1] += size
+            matched = True
+            break
+    if matched:
+        continue
+    if 'llvm::' in name:
+        llvm_other[0] += 1
+        llvm_other[1] += size
+    else:
+        non_llvm[0] += 1
+        non_llvm[1] += size
+
+print(f"binary: {binary}")
+print(f"approx code (text): {total/1024/1024:.2f} MB across {len(entries):,} symbols")
+print()
+print("=== LLVM TARGETS (cross-compile backends) ===")
+print(f"{'target':<14} {'symbols':>9}   {'MB':>7}   {'%text':>6}")
+target_total = 0
+for t, (c, b) in sorted(target_size.items(), key=lambda kv: -kv[1][1]):
+    if c == 0:
+        continue
+    target_total += b
+    print(f"  {t:<12} {c:>9,}   {b/1024/1024:>7.2f}   {b/total*100:>5.2f}%")
+print(f"  {'(targets sum)':<12} {'':>9}   {target_total/1024/1024:>7.2f}   {target_total/total*100:>5.2f}%")
+print()
+print("=== OTHER LLVM COMPONENTS ===")
+print(f"{'component':<14} {'symbols':>9}   {'MB':>7}   {'%text':>6}")
+comp_total = 0
+for k, (c, b) in sorted(comp_size.items(), key=lambda kv: -kv[1][1]):
+    comp_total += b
+    print(f"  {k:<12} {c:>9,}   {b/1024/1024:>7.2f}   {b/total*100:>5.2f}%")
+print(f"  llvm::other  {llvm_other[0]:>9,}   {llvm_other[1]/1024/1024:>7.2f}   {llvm_other[1]/total*100:>5.2f}%")
+print()
+print("=== NON-LLVM ===")
+print(f"  {non_llvm[0]:>9,} symbols   {non_llvm[1]/1024/1024:>7.2f} MB   {non_llvm[1]/total*100:>5.2f}%")


### PR DESCRIPTION
## Summary

Three perf wins on the same branch:

1. **Startup** — culebra hello-world: 993 ms → 27.6 ms (36×, on par with python). Lazy-register stdlib modules (Time, Args) in the env instead of parsing + evaluating their 14 KB of culebra source on every startup. JIT/AOT use a substring-match selective preamble.

2. **CI** — Ubuntu CI: 8m39s → 1m58s (4.4×), macOS CI: 5m19s → 2m9s (2.5×). ccache for compiler outputs + mold linker on Linux.

3. **Binary size + LTO** — `culebra` binary: 175 MB → **71 MB** (-59%). `CULEBRA_LLVM_ALL_TARGETS` (default OFF) trims cross-compile LLVM backends; `CULEBRA_LTO` (default ON) enables ThinLTO. JIT runtime gains **+6.7%** from LTO as a permanent bonus for every end user.

## Benchmarks

### Startup (M1, hyperfine, hello-world)

| runtime           | before     | after       | speedup            |
|-------------------|------------|-------------|--------------------|
| python3           | 22.7 ms    | 22.7 ms     | (baseline)         |
| **culebra interp** | **993 ms** | **27.6 ms** | **36×**            |
| culebra --jit     | 1100 ms    | 50.3 ms     | 22×                |
| culebra build     | 1400 ms    | 98 ms       | 14× (AOT compile)  |
| AOT runtime       | 2.2 ms     | 2.2 ms      | unchanged          |

### CI build time (warm)

| OS     | before | after (warm) | speedup |
|--------|--------|--------------|---------|
| Ubuntu | 8m39s  | **~2m**      | ~4×     |
| macOS  | 5m19s  | **~2m**      | ~2.5×   |

(LTO default ON adds ~25 s to the link step vs LTO-off measurements; still vastly faster than the 8m39s baseline thanks to ccache + mold.)

### Binary size (macOS arm64)

|                          | size       | vs Bun (60 MB) |
|--------------------------|------------|----------------|
| Before (AllTargets, no LTO) | 175.46 MB  | 2.9×           |
| **After (`just build`)** | **71.28 MB** | **1.19×** ← on par with Node (85 MB) |

### JIT runtime performance with LTO (fib(28))

| build              | time      | delta |
|--------------------|-----------|-------|
| LTO OFF            | 286.3 ms  | baseline |
| **LTO ON (default)** | **267.1 ms** | **-6.7%** |

LTO gives every built binary a permanent +6.7% on JIT-compiled code, applied to all end users.

## Commits

- `feat(startup): lazy stdlib modules + selective preamble`
- `ci: cache compiler outputs (ccache) and switch Linux to mold linker`
- `build: trim LLVM cross-compile backends by default (-50% binary)`
- `build: enable ThinLTO by default`

## Design notes

### Lazy stdlib modules

`Symbol` is unchanged. `Environment::lazy_pending` (map from unresolved name to source) and `lazy_module_sources` (vector owning the strings) handle lazy bookkeeping at the env layer. The owner is necessary because `peg::Ast` tokens hold `string_view`s into the source — class methods bound during resolution outlive the resolution call, so the source buffer must outlive the env that owns those methods.

`Environment::get` fast-paths empty `lazy_pending` so post-resolution lookups have no overhead.

### Selective preamble (JIT/AOT)

JIT/AOT can't use the env's lazy machinery (IR is built statically). Instead the user source is substring-matched for \`Time\` / \`Args\` and only the referenced modules are prepended. False positives (e.g. `let myTime = 1`) over-include harmlessly; only true negatives skip the prepend, so correctness is preserved.

JIT REPL is intentionally left eager — an interactive session can't predict future input.

### Binary size + LTO

`CULEBRA_LLVM_ALL_TARGETS=OFF` (default) links Native + WebAssembly only. Cross-compile users opt in with `cmake -DCULEBRA_LLVM_ALL_TARGETS=ON`. The runtime registration (`ensure_all_targets_init` in jit.h) branches on the same flag.

`CULEBRA_LTO=ON` (default) enables ThinLTO for every Release build — the +6.7% JIT speedup applies to all binaries (contributor builds, CI artifacts, future Homebrew formula). The cost is ~25 s of extra link time per build. Contributors who want to skip LTO during iteration loops can pass `cmake -DCULEBRA_LTO=OFF`.

The -59% total size trim comes from two effects: (1) AllTargets→Native+WASM drops the per-target LLVM code, and (2) dropping AllTargets lets the linker dead-strip LLVM-internal code (yaml, sandboxir, sampleprof, etc.) that was previously kept alive transitively.

### Build recipes

Just two:

- `just build` — default, Release + JIT + LTO (71 MB)
- `just build-no-jit` — interpreter only, no LLVM (3.18 MB sanity check; the future `culebra-runtime` distribution candidate)

## Test plan

- [x] `just test all` green (interp + JIT + AOT + ctest)
- [x] hyperfine: hello / time_use / args_use / fib across interp / --jit / culebra build
- [x] CI passes (warm-cache rerun shows 2-4× speedup over baseline)
- [ ] Reviewer to confirm `cmake -DCULEBRA_LLVM_ALL_TARGETS=ON` still produces a working cross-compile build