### PR TITLE
type-system: Generic bound constraints + composite bounds + trait inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ CMakeCache.txt
 
 # Build directory
 build/
+build-dev/
 
 # macOS metadata
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,17 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
 endif()
 
+# Use ccache as the compiler launcher when available. Keeps a content-
+# addressed cache of .o files in ~/.cache/ccache so that header touches
+# that don't change content (e.g. branch switching) hit the cache and
+# skip the compile. Auto-disabled if ccache isn't installed.
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  message(STATUS "ccache: ${CCACHE_PROGRAM}")
+endif()
+
 # ThinLTO trims ~15 MB off the Release `culebra` driver and gives the
 # JIT runtime a permanent +6.7% (cross-TU inlining of codegen). Cost
 # is ~25 s extra link time per build. Disable with `-DCULEBRA_LTO=OFF`

--- a/docs/language.ja.md
+++ b/docs/language.ja.md
@@ -1580,8 +1580,8 @@ Generic クラスを型注釈で使う構文は組み込み Generic 型と同じ
 * expression 位置の type args (`Box<Long>.new(42)`) — parser は
   現状 `<...>` を型注釈 context のみで使用。
 * opt-in 要素 runtime check。
-* 複合 Bound (`<T: A + B>`) / `where` 節 / trait 継承
-  (`trait Ord: Eq`) — 単一 Bound は実装済。
+* trait 継承 (`trait Ord: Eq`) — Phase 4+。 単一・複合 Bound
+  (`<T: Comparable>`, `<T: A + B>`) は実装済。
 * class body 内 class 宣言 (現状は SyntaxError、 上記「クラス宣言の
   位置」参照)。
 
@@ -1742,6 +1742,14 @@ culebra の型 check は runtime)。 帰結:
 無制約 `<T>` は任意の引数を受ける (`Any` に lower される) — param に
 名前を付け、 より特異な overload に負けるための形。
 
+**複合 bound** `<T: A + B>` も使える — arg は **全パート**に conform
+する必要がある (Union の any-of に対する all-of)。 spacing は寛容
+(`<T:A+B>` も可)。
+
+    fn both<T: Hashable + Stringer>(x: T) { x }
+    both(5)        # OK — Long は両方に conform
+    both([1, 2])   # !! Array は Stringer だが Hashable でない -> reject
+
 #### dispatch tie-break
 
 trait param のスコアは Object と具象の中間。 同じ関数名で `x: Pri`
@@ -1753,8 +1761,9 @@ trait path のみ match する場合は trait 版が選ばれる。
 * `impl Foo for Bar` block は未対応 — 構造的のみ。 (Phase 4+ で
   明示宣言を再検討)
 * trait 継承 (`trait Ord: Eq`) は未対応。
-* 複合 Bound (`<T: A + B>`) と `where` 節 — Phase 4+。
-  単一 Bound (`<T: Comparable>`) は実装済 (上記「Generic Bound」)。
+* trait 継承 (`trait Ord: Eq`) — Phase 4+。
+  単一・複合 Bound (`<T: Comparable>`, `<T: A + B>`) は実装済
+  (上記「Generic Bound」)。
 * **演算子オーバーロードは trait default を bypass する**: `<` /
   `==` 等は class の `__lt__` / `__eq__` を直接呼ぶ。 Comparable の
   default `lt` / `le` 等は `x.lt(y)` の form のみ動作。 `cmp` を持つ

--- a/docs/language.ja.md
+++ b/docs/language.ja.md
@@ -1551,10 +1551,11 @@ lambda / lexical-scope (`{ ... }`) の中 (新しい scope を開く) のみ
       new (k, v) { this.k = k; this.v = v }
     }
 
-このフェーズでは型パラメータはドキュメント — メソッドのシグネチャを
-読みやすくするためのものであり、 runtime は `Any` として扱います。
-class は外側名 (`Box`, `Pair`) で bind され、インスタンスは外側の
-class tag を持ちます:
+制約なしの型パラメータはドキュメント — メソッドのシグネチャを
+読みやすくするためのもので、 runtime は `Any` として扱います。
+**Bound 付き** (`<T: Comparable>`) は強制されます (後述「Generic
+Bound」)。 class は外側名 (`Box`, `Pair`) で bind され、インスタンス
+は外側の class tag を持ちます:
 
     let b = Box.new(42)
     b.class                 # → 'Box'
@@ -1579,7 +1580,8 @@ Generic クラスを型注釈で使う構文は組み込み Generic 型と同じ
 * expression 位置の type args (`Box<Long>.new(42)`) — parser は
   現状 `<...>` を型注釈 context のみで使用。
 * opt-in 要素 runtime check。
-* Bound 制約 (`<T: Comparable>`) — trait / protocol 導入次第。
+* 複合 Bound (`<T: A + B>`) / `where` 節 / trait 継承
+  (`trait Ord: Eq`) — 単一 Bound は実装済。
 * class body 内 class 宣言 (現状は SyntaxError、 上記「クラス宣言の
   位置」参照)。
 
@@ -1699,15 +1701,46 @@ class を Object / Set key にする場合は対応する `eq(other)` の同時
 
 #### Generic Bound
 
-型パラメータに trait 制約を付けられる (Rust inline 流):
+型パラメータに trait 制約を付けられる (Rust inline 流)。 free 関数・
+class の両方で使え、 **呼び出し境界で強制**される (bound に conform
+しない値はその param の引数にならない):
 
-    fn min<T: Comparable>(a: T, b: T) -> T {
-      if a.lt(b) { a } else { b }
+    class Money {
+      new(amount) { this.amount = amount }
+      cmp(other) { this.amount - other.amount }   # Comparable に conform
     }
+    fn pick_max<T: Comparable>(a: T, b: T) {
+      if a.gt(b) { a } else { b }                 # gt は Comparable の default
+    }
+    pick_max(Money.new(10), Money.new(25)).amount   # → 25
+    pick_max([1], [2])                              # !! no matching method
 
-Bound はドキュメント + dispatch のみ (compile-time check なし、
-culebra の型 check は runtime)。 複数 Bound (`<T: A + B>`) や
-`where` 節は MVP 範囲外。
+Bound は宣言時に **bound trait へ lower** され、 通常の trait
+conformance 機構をそのまま再利用する (compile-time check なし、
+culebra の型 check は runtime)。 帰結:
+
+* **dispatch 特異性**は trait レベル: 具象 overload > bounded >
+  無制約 `<T>` catch-all。
+
+      fn rank(x: Long) { "concrete" }
+      fn rank<T: Comparable>(x: T) { "bounded" }
+      fn rank<T>(x: T) { "unbounded" }
+      rank(5)     # → "concrete"
+      rank(1.5)   # → "bounded"    (Float は Comparable)
+      rank([1])   # → "unbounded"  (Array はどちらにも非適合)
+
+* **lenient 単一化**: 同じ型パラメータが複数位置に出る (`a: T,
+  b: T`) とき、 bound は *各位置で個別に* 検査され、 繰り返しの `T`
+  は単一の concrete 型に強制されない。 `(a: T, b: T)` の関数は
+  `(1, 2.0)` を受理する (両方 `Comparable`)。
+
+* bound は conformance を強制するが、 後述の **primitive method
+  surface 制限**は残る: `a.gt(b)` は `a` が object のときのみ
+  dispatch される。 primitive 引数では body で native な `<` / `>`
+  を使う。
+
+無制約 `<T>` は任意の引数を受ける (`Any` に lower される) — param に
+名前を付け、 より特異な overload に負けるための形。
 
 #### dispatch tie-break
 
@@ -1721,10 +1754,7 @@ trait path のみ match する場合は trait 版が選ばれる。
   明示宣言を再検討)
 * trait 継承 (`trait Ord: Eq`) は未対応。
 * 複合 Bound (`<T: A + B>`) と `where` 節 — Phase 4+。
-* **Bound は構文受理のみ**: `<T: Comparable>` は parse 通るが
-  dispatch / runtime では bound を見ない。 body 内の `T` は `Any`
-  に書き換えられる。 Phase 4+ で multifn dispatch / Generic 呼び出し
-  時 check に連動。
+  単一 Bound (`<T: Comparable>`) は実装済 (上記「Generic Bound」)。
 * **演算子オーバーロードは trait default を bypass する**: `<` /
   `==` 等は class の `__lt__` / `__eq__` を直接呼ぶ。 Comparable の
   default `lt` / `le` 等は `x.lt(y)` の form のみ動作。 `cmp` を持つ

--- a/docs/language.ja.md
+++ b/docs/language.ja.md
@@ -1580,8 +1580,6 @@ Generic クラスを型注釈で使う構文は組み込み Generic 型と同じ
 * expression 位置の type args (`Box<Long>.new(42)`) — parser は
   現状 `<...>` を型注釈 context のみで使用。
 * opt-in 要素 runtime check。
-* trait 継承 (`trait Ord: Eq`) — Phase 4+。 単一・複合 Bound
-  (`<T: Comparable>`, `<T: A + B>`) は実装済。
 * class body 内 class 宣言 (現状は SyntaxError、 上記「クラス宣言の
   位置」参照)。
 
@@ -1756,14 +1754,28 @@ trait param のスコアは Object と具象の中間。 同じ関数名で `x: 
 と `x: Stringer` の overload があれば、 arg が Pri なら具象が勝つ。
 trait path のみ match する場合は trait 版が選ばれる。
 
+#### trait 継承
+
+trait は `:` の後に supertrait を宣言できる: `trait Ord: Eq`、
+`trait Both: Eq, Show`。 supertrait の method は subtrait に flatten
+される — `Ord` に conform するには `Eq` と `Ord` の**両方**の required
+method が要る。 推移的に効き (`Done: Ord` は `Eq` も引き込む)、
+supertrait の **default** method も subtrait で使える。
+
+    trait Eq  { eq(other) -> Bool }
+    trait Ord: Eq { cmp(other) -> Long }   # Ord conform には eq + cmp
+
+    fn sorted<T: Ord>(xs: Array<T>) { ... }
+
+supertrait は継承する trait より前に宣言する必要がある (宣言順で
+flatten を解決)。 primitive 型の conformance は名前ベース (hard-coded
+table) なので、 trait 継承は **構造的 (class) conformance のみ**に
+効く — primitive が supertrait 経由で user trait を満たすことはない。
+
 #### 制限 (Phase 4 MVP)
 
 * `impl Foo for Bar` block は未対応 — 構造的のみ。 (Phase 4+ で
   明示宣言を再検討)
-* trait 継承 (`trait Ord: Eq`) は未対応。
-* trait 継承 (`trait Ord: Eq`) — Phase 4+。
-  単一・複合 Bound (`<T: Comparable>`, `<T: A + B>`) は実装済
-  (上記「Generic Bound」)。
 * **演算子オーバーロードは trait default を bypass する**: `<` /
   `==` 等は class の `__lt__` / `__eq__` を直接呼ぶ。 Comparable の
   default `lt` / `le` 等は `x.lt(y)` の form のみ動作。 `cmp` を持つ

--- a/docs/language.md
+++ b/docs/language.md
@@ -1624,10 +1624,11 @@ A class can declare type parameters:
       new (k, v) { this.k = k; this.v = v }
     }
 
-Type parameters are documentation in this phase — they make method
-signatures readable but the runtime sees them as `Any`. The
-class is bound under the outer name (`Box`, `Pair`), and instances
-carry the outer class tag:
+An unbounded type parameter is documentation — it makes method
+signatures readable but the runtime sees it as `Any`. A *bounded*
+parameter (`<T: Comparable>`) is enforced; see "Bound constraints"
+below. The class is bound under the outer name (`Box`, `Pair`), and
+instances carry the outer class tag:
 
     let b = Box.new(42)
     b.class                 # → 'Box'
@@ -1637,6 +1638,53 @@ syntax as built-in Generic types and behave the same way (outer
 match):
 
     fn unbox(b: Box<Long>) -> Long { b.v }
+
+#### Bound constraints
+
+A type parameter may carry a bound — a trait the bound type must
+conform to: `<T: Comparable>`. The bound applies on both free
+functions and classes, and is enforced at the call boundary: a value
+that does not conform to the bound is not a valid argument for that
+parameter. Inside the body, the bound's default methods are available
+on object arguments (`a.gt(b)` for a `Comparable` class).
+
+    class Money {
+      new(amount) { this.amount = amount }
+      cmp(other) { this.amount - other.amount }   # conforms to Comparable
+    }
+    fn pick_max<T: Comparable>(a: T, b: T) {
+      if a.gt(b) { a } else { b }                 # gt is a Comparable default
+    }
+    pick_max(Money.new(10), Money.new(25)).amount   # → 25
+    pick_max([1], [2])                              # !! no matching method
+
+Bounds are *lowered to the bound trait* at declaration time, so they
+reuse the ordinary trait-conformance machinery. Three consequences:
+
+* **Dispatch specificity** sits at the trait level: a concrete
+  overload beats a bounded one, and a bounded one beats an unbounded
+  `<T>` catch-all.
+
+      fn rank(x: Long) { "concrete" }
+      fn rank<T: Comparable>(x: T) { "bounded" }
+      fn rank<T>(x: T) { "unbounded" }
+      rank(5)     # → "concrete"   (exact type)
+      rank(1.5)   # → "bounded"    (Float conforms to Comparable)
+      rank([1])   # → "unbounded"  (Array conforms to neither)
+
+* **Lenient unification**: a type parameter that appears in several
+  positions (`a: T, b: T`) checks the bound at *each* position
+  independently — repeated `T` is not forced to a single concrete
+  type. A function taking `(a: T, b: T)` accepts `(1, 2.0)` (both
+  `Comparable`).
+
+* The bound enforces conformance, but the **primitive method-surface
+  limitation** still applies: `a.gt(b)` only dispatches when `a` is an
+  object. For primitive arguments use the native `<` / `>` operators
+  in the body instead.
+
+An unbounded `<T>` accepts any argument (it lowers to `Any`); it
+exists to name a parameter and to lose to more specific overloads.
 
 #### Known limitations
 
@@ -1655,8 +1703,8 @@ match):
 * Expression-position type args (`Box<Long>.new(42)`) — the parser
   currently reserves `<...>` for type-annotation contexts only.
 * Opt-in element runtime check.
-* Bound constraints (`<T: Comparable>`) — depends on trait /
-  protocol introduction.
+* Composite bounds (`<T: A + B>`), `where` clauses, and trait
+  inheritance (`trait Ord: Eq`) — single bounds ship today.
 * Class declarations inside another class's body (currently a
   SyntaxError, see "Where class declarations may appear" above).
 
@@ -1790,9 +1838,11 @@ inline (Rust style):
       if a.lt(b) { a } else { b }
     }
 
-The Bound is documentation + dispatch (no compile-time check;
-culebra's type checks are runtime). Multiple bounds (`<T: A + B>`)
-and `where` clauses are not yet supported.
+The bound is **enforced** at the call boundary (no compile-time
+check; culebra's type checks are runtime) — see "Bound constraints"
+under Generic types for the full semantics (lowering, dispatch
+ordering, lenient unification). Multiple bounds (`<T: A + B>`) and
+`where` clauses are not yet supported.
 
 #### Dispatch tie-break
 
@@ -1807,10 +1857,7 @@ chosen when only the trait path matches.
   structural. (Phase 4+: revisit if explicit conformance is wanted.)
 * Trait inheritance (`trait Ord: Eq`) is not yet supported.
 * Bound composition (`<T: A + B>`) and `where` clauses — Phase 4+.
-* **Bound is parse-receipt-only**: `<T: Comparable>` parses, but the
-  dispatch / runtime currently does not consult the bound. T inside
-  the body is rewritten to `Any`. Phase 4+ will tie the bound into
-  multifn dispatch and Generic-call-site checking.
+  Single bounds (`<T: Comparable>`) are enforced today.
 * **Operator overloads bypass trait defaults**: `<` / `==` etc.
   invoke `__lt__` / `__eq__` directly on the class; Comparable's
   default `lt` / `le` etc. only fire when called as `x.lt(y)`. A

--- a/docs/language.md
+++ b/docs/language.md
@@ -1686,6 +1686,14 @@ reuse the ordinary trait-conformance machinery. Three consequences:
 An unbounded `<T>` accepts any argument (it lowers to `Any`); it
 exists to name a parameter and to lose to more specific overloads.
 
+A **composite bound** `<T: A + B>` requires the argument to conform to
+**all** parts (the all-of dual of a Union). Spacing is tolerated
+(`<T:A+B>` works too).
+
+    fn both<T: Hashable + Stringer>(x: T) { x }
+    both(5)        # OK — Long conforms to both
+    both([1, 2])   # !! Array is Stringer but not Hashable -> rejected
+
 #### Known limitations
 
 * Two overloads sharing an outer Generic name (`fn show(xs:
@@ -1703,8 +1711,8 @@ exists to name a parameter and to lose to more specific overloads.
 * Expression-position type args (`Box<Long>.new(42)`) — the parser
   currently reserves `<...>` for type-annotation contexts only.
 * Opt-in element runtime check.
-* Composite bounds (`<T: A + B>`), `where` clauses, and trait
-  inheritance (`trait Ord: Eq`) — single bounds ship today.
+* Trait inheritance (`trait Ord: Eq`). Single and composite bounds
+  (`<T: Comparable>`, `<T: A + B>`) ship today.
 * Class declarations inside another class's body (currently a
   SyntaxError, see "Where class declarations may appear" above).
 
@@ -1841,8 +1849,10 @@ inline (Rust style):
 The bound is **enforced** at the call boundary (no compile-time
 check; culebra's type checks are runtime) — see "Bound constraints"
 under Generic types for the full semantics (lowering, dispatch
-ordering, lenient unification). Multiple bounds (`<T: A + B>`) and
-`where` clauses are not yet supported.
+ordering, lenient unification). A composite bound `<T: A + B>` is
+also supported — the argument must conform to **all** parts (the
+all-of dual of a Union). `where` clauses are not planned (the inline
+form already covers the cases).
 
 #### Dispatch tie-break
 
@@ -1856,8 +1866,9 @@ chosen when only the trait path matches.
 * `impl Foo for Bar` block is unsupported — conformance is purely
   structural. (Phase 4+: revisit if explicit conformance is wanted.)
 * Trait inheritance (`trait Ord: Eq`) is not yet supported.
-* Bound composition (`<T: A + B>`) and `where` clauses — Phase 4+.
-  Single bounds (`<T: Comparable>`) are enforced today.
+* Trait inheritance (`trait Ord: Eq`) — Phase 4+. Single and
+  composite bounds (`<T: Comparable>`, `<T: A + B>`) are enforced
+  today.
 * **Operator overloads bypass trait defaults**: `<` / `==` etc.
   invoke `__lt__` / `__eq__` directly on the class; Comparable's
   default `lt` / `le` etc. only fire when called as `x.lt(y)`. A

--- a/docs/language.md
+++ b/docs/language.md
@@ -1711,8 +1711,6 @@ A **composite bound** `<T: A + B>` requires the argument to conform to
 * Expression-position type args (`Box<Long>.new(42)`) — the parser
   currently reserves `<...>` for type-annotation contexts only.
 * Opt-in element runtime check.
-* Trait inheritance (`trait Ord: Eq`). Single and composite bounds
-  (`<T: Comparable>`, `<T: A + B>`) ship today.
 * Class declarations inside another class's body (currently a
   SyntaxError, see "Where class declarations may appear" above).
 
@@ -1861,14 +1859,31 @@ dispatch: a method with `x: Pri` wins over a method with
 `x: Stringer` when the arg is a Pri instance; `x: Stringer` is
 chosen when only the trait path matches.
 
+#### Trait inheritance
+
+A trait may declare supertraits after a colon: `trait Ord: Eq`,
+`trait Both: Eq, Show`. The supertrait's methods are flattened into
+the subtrait, so a value conforming to `Ord` must supply **both**
+`Eq`'s and `Ord`'s required methods. This works transitively
+(`Done: Ord` pulls in `Eq` too) and a supertrait's *default* methods
+become available on the subtrait.
+
+    trait Eq  { eq(other) -> Bool }
+    trait Ord: Eq { cmp(other) -> Long }   # conforming to Ord needs eq + cmp
+
+    fn sorted<T: Ord>(xs: Array<T>) { ... }
+
+Supertraits must be declared before the trait that inherits them
+(declaration order resolves the flatten). Because conformance for
+built-in primitive types is name-based (a hard-coded table), trait
+inheritance affects **structural (class) conformance** only — a
+primitive does not retroactively satisfy a user trait via its
+supertrait.
+
 #### Limitations (Phase 4 MVP)
 
 * `impl Foo for Bar` block is unsupported — conformance is purely
   structural. (Phase 4+: revisit if explicit conformance is wanted.)
-* Trait inheritance (`trait Ord: Eq`) is not yet supported.
-* Trait inheritance (`trait Ord: Eq`) — Phase 4+. Single and
-  composite bounds (`<T: Comparable>`, `<T: A + B>`) are enforced
-  today.
 * **Operator overloads bypass trait defaults**: `<` / `==` etc.
   invoke `__lt__` / `__eq__` directly on the class; Comparable's
   default `lt` / `le` etc. only fire when called as `x.lt(y)`. A

--- a/include/generator_transform.h
+++ b/include/generator_transform.h
@@ -190,13 +190,18 @@ inline std::string_view strip_block_braces(std::string_view s) {
   return s;
 }
 
-// Rewrite every `\b<name>\b` in `src` to `this.<name>` for each name in
-// `names`, then strip `let `/`mut ` prefixes that now sit in front of
-// `this.X` (assignment, no longer declaration). Stage 2 spike uses a
-// regex word-boundary pass — adequate for counter/fib bodies; the
-// edge cases (string literals / comments containing local names,
-// for-in loop bindings) are out of Stage 2 scope and surface as
-// transformation bugs to revisit if hit.
+// Rewrite every standalone `<name>` in `src` to `this.<name>` for each
+// name in `names`, then strip `let `/`mut ` prefixes that now sit in
+// front of `this.X` (assignment, no longer declaration).
+//
+// The match requires the identifier NOT be preceded by `.` — so a
+// member access like `arr.size()` is left alone even when a local/param
+// is named `size`. Without this, `\bsize\b` rewrote the `.size()` method
+// name to `arr.this.size()`, producing malformed source (a parser crash
+// for any generator whose binding collides with a builtin method like
+// size / push / keys). The same `.`-exclusion also prevents re-rewriting
+// the `this.` prefixes this pass just inserted. String-literal and
+// comment false positives remain out of scope (regex, not a real lexer).
 inline std::string rewrite_locals_to_this(std::string_view src,
                                           const std::set<std::string>& names) {
   // The two declaration-strip patterns are name-independent — hoist
@@ -209,8 +214,11 @@ inline std::string rewrite_locals_to_this(std::string_view src,
   std::sort(sorted.begin(), sorted.end(),
             [](const auto& a, const auto& b) { return a.size() > b.size(); });
   for (const auto& name : sorted) {
-    std::regex pat("\\b" + name + "\\b");
-    out = std::regex_replace(out, pat, "this." + name);
+    // Group 1 captures the boundary char (start-of-string or any byte
+    // that is neither `.` nor an identifier char) so it can be restored
+    // ahead of the inserted `this.`.
+    std::regex pat("(^|[^.A-Za-z0-9_])" + name + "\\b");
+    out = std::regex_replace(out, pat, "$1this." + name);
   }
   out = std::regex_replace(out, strip_let_this, "this.");
   out = std::regex_replace(out, strip_mut_this, "this.");

--- a/include/generator_transform.h
+++ b/include/generator_transform.h
@@ -78,6 +78,57 @@ inline bool fn_body_has_yield(const peg::Ast& node) {
   return false;
 }
 
+// Collect every DEFER node in a fn body in source order, stopping at
+// inner fn boundaries. Used by the dispatcher to verify that all defers
+// live at the body's top level (where Stage 3 emits them into the
+// generator's defer registry); defers buried inside loop/if bodies have
+// no good translation today and surface as a SyntaxError.
+inline std::vector<const peg::Ast*> collect_defers(const peg::Ast& body) {
+  using namespace peg::udl;
+  std::vector<const peg::Ast*> out;
+  std::function<void(const peg::Ast&)> walk = [&](const peg::Ast& n) {
+    if (is_fn_boundary(n.tag)) return;
+    if (n.tag == "DEFER"_) { out.push_back(&n); return; }
+    for (auto& c : n.nodes) walk(*c);
+  };
+  walk(body);
+  return out;
+}
+
+// Locate the first YIELD reachable from inside a TRY's try-block / catch
+// block, or from inside a DEFER's body. Returns nullptr if no such yield
+// exists. Used by the dispatcher to enforce the C# rule (CS1626): yield
+// statements may not appear inside a try-catch or defer. `yield try {...}
+// catch e {...}` is fine because the yield is OUTSIDE the try (only the
+// try-expression's value flows through it) — the guard descends into a
+// TRY's body BLOCKs but not into its position as an expression.
+inline const peg::Ast* find_yield_inside_try_or_defer(const peg::Ast& body) {
+  using namespace peg::udl;
+  const peg::Ast* found = nullptr;
+  std::function<void(const peg::Ast&, bool)> walk =
+      [&](const peg::Ast& n, bool inside_guard) {
+        if (found) return;
+        if (is_fn_boundary(n.tag)) return;
+        if (inside_guard && (n.tag == "YIELD"_ || n.tag == "YIELD_FROM"_)) {
+          found = &n;
+          return;
+        }
+        if (n.tag == "TRY"_) {
+          // TRY children: try-BLOCK, catch-IDENT, catch-BLOCK
+          if (n.nodes.size() > 0) walk(*n.nodes[0], true);
+          if (n.nodes.size() > 2) walk(*n.nodes[2], true);
+          return;
+        }
+        if (n.tag == "DEFER"_) {
+          if (!n.nodes.empty()) walk(*n.nodes[0], true);
+          return;
+        }
+        for (auto& c : n.nodes) walk(*c, inside_guard);
+      };
+  walk(body, false);
+  return found;
+}
+
 // Collect every YIELD inside a fn body in source order, stopping at
 // inner fn boundaries (same rule as `fn_body_has_yield`).
 inline std::vector<const peg::Ast*> collect_yields(const peg::Ast& node) {
@@ -388,7 +439,10 @@ inline bool swap_body_with_wrapper_params(
 // Stage 1: yield expressions are eager-evaluated in the factory and
 // passed through positional ctor args `_y0, _y1, ...`. Works for any
 // body whose yields depend only on params/literals — see
-// [[project-generator-design]] §Stage 1.
+// [[project-generator-design]] §Stage 1. The class carries a no-op
+// `dispose()` so for-in's unconditional cleanup call lands on a real
+// method (the dispatcher already rejects Stage 1 bodies that try to
+// use `defer`, so there's nothing to actually run here).
 inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage1(
     std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len,
     const peg::Ast& name_ast,
@@ -430,6 +484,7 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage1(
       "{4}"
       "      return nil\n"
       "    }}\n"
+      "    dispose() {{}}\n"
       "  }}\n"
       "  {0}.new({5})\n"
       "}}\n",
@@ -466,6 +521,44 @@ inline std::string substitute_yields_in_stmt(
     out.replace(local_pos, y->length, replacement);
   }
   return out;
+}
+
+// Split pre-loop into (a) the non-defer statements (kept inline) and
+// (b) the LIFO-ordered defer bodies (lifted into the generator's
+// `dispose()` method directly, inlined rather than wrapped in
+// closures). Inlining sidesteps a JIT limitation around `this` capture
+// in closures created from method bodies, and the closure indirection
+// wasn't doing anything Stage 6a's minimum scope needed anyway —
+// defers at body top level are unconditional, so reach + run are
+// equivalent. The dispose code is gated on `_g_inited` so a generator
+// disposed before any iteration doesn't fire defers whose locals
+// haven't been initialized yet.
+inline void split_pre_loop_stmts_and_defers(
+    const std::vector<const peg::Ast*>& stmts,
+    const char* src, size_t src_len,
+    const std::set<std::string>& rewrite_set,
+    std::string& out_stmts,
+    std::string& out_dispose_body) {
+  using namespace peg::udl;
+  std::vector<std::string> defer_bodies;
+  for (auto* stmt : stmts) {
+    auto* unwrapped = unwrap_stmt(stmt);
+    if (unwrapped->tag == "DEFER"_ && !unwrapped->nodes.empty()) {
+      auto block_sv = ast_source_slice(*unwrapped->nodes[0], src, src_len);
+      auto inner_sv = strip_block_braces(block_sv);
+      defer_bodies.push_back(rewrite_locals_to_this(inner_sv, rewrite_set));
+    } else {
+      auto stmt_sv = ast_source_slice(*stmt, src, src_len);
+      out_stmts += rewrite_locals_to_this(stmt_sv, rewrite_set);
+      out_stmts += "\n";
+    }
+  }
+  // LIFO: last-registered defer runs first.
+  for (auto it = defer_bodies.rbegin(); it != defer_bodies.rend(); ++it) {
+    out_dispose_body += "        ";
+    out_dispose_body += *it;
+    out_dispose_body += "\n";
+  }
 }
 
 // Stage 3: while-loop body whose yields all live inside one statement
@@ -507,7 +600,8 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage3(
       "      this._g_drained = false\n"
       "      this._g_has_la = false\n"
       "      this._g_la = nil\n"
-      "      this._g_inited = false\n";
+      "      this._g_inited = false\n"
+      "      this._g_disposed = false\n";
   std::set<std::string> param_set;
   for (size_t j = 0; j < param_names.size(); j++) {
     auto pn = std::string(param_names[j]);
@@ -528,8 +622,14 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage3(
   }
 
   // Rewrite each body fragment to use `this.X` for params + locals.
-  auto pre_loop_src = rewrite_locals_to_this(
-      ast_source_range(p.pre_loop, src, src_len), rewrite_set);
+  // pre_loop walks statements one by one so DEFER nodes can be lifted
+  // into the dispose method directly (inlined, not wrapped in closures
+  // — JIT can't capture `this` through a method-local closure today).
+  std::string pre_loop_src;
+  std::string dispose_body_src;
+  split_pre_loop_stmts_and_defers(
+      p.pre_loop, src, src_len, rewrite_set,
+      pre_loop_src, dispose_body_src);
   auto pre_yield_src = rewrite_locals_to_this(
       ast_source_range(p.pre_yield, src, src_len), rewrite_set);
   auto post_yield_src = rewrite_locals_to_this(
@@ -574,13 +674,21 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage3(
       "      this._g_has_la = false\n"
       "      return _v\n"
       "    }}\n"
+      "    dispose() {{\n"
+      "      if this._g_disposed {{ return nil }}\n"
+      "      this._g_disposed = true\n"
+      "      this._g_drained = true\n"
+      "      if this._g_inited {{\n"
+      "{10}"
+      "      }}\n"
+      "    }}\n"
       "  }}\n"
       "  {0}.new({9})\n"
       "}}\n",
       gen_name, ctor_params, ctor_inits,
       post_yield_src, pre_loop_src,
       cond_src, pre_yield_src, yield_stmt_src, post_yield_src,
-      ctor_call_args));
+      ctor_call_args, dispose_body_src));
   swap_body_from_wrapper(ast, synthesized);
   return ast;
 }
@@ -602,6 +710,22 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
   auto yields = collect_yields(*ast->nodes.back());
   if (yields.empty()) return ast;
 
+  // C# rule (CS1626): a yield statement may not appear inside a try-catch
+  // or defer block. The state-machine cost of supporting yield-spanning
+  // try blocks is permanently out of scope for culebra ([[generator-design]]
+  // §仕様凍結項目). Cleanup belongs in `defer { ... }` at body top level;
+  // value-level error recovery belongs in the yielded expression
+  // (`yield try { ... } catch e { ... }`).
+  if (auto* bad = find_yield_inside_try_or_defer(*ast->nodes.back())) {
+    throw CulebraError(
+        "SyntaxError",
+        "yield cannot appear inside a try-catch or defer block. Move "
+        "the try to the yielded expression value (yield try { ... } "
+        "catch e { ... }) or use a top-level `defer { ... }` for cleanup.",
+        static_cast<long>(bad->line),
+        static_cast<long>(bad->column));
+  }
+
   // Stage 5: rewrite yielding for-in loops to while + iterator at source
   // level, then re-parse so Stage 3 picks them up.
   if (auto rewritten = rewrite_yielding_fors_to_while(
@@ -618,11 +742,45 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
     if (yields.empty()) return ast;
   }
 
+  // Stage 6a defer scope: only top-level `defer { ... }` in the body is
+  // supported (lifted into the generator's defer registry at dispose
+  // time). Defers buried in loop / if / match bodies have no clean
+  // translation today — surface as a SyntaxError instead of silently
+  // letting the existing scope-local defer mechanism mis-fire on yield.
+  auto all_defers = collect_defers(*ast->nodes.back());
   const auto& name_ast = *ast->nodes[i];
   const auto& params_ast = *ast->nodes[i + 1];
   if (auto p = match_stage3_pattern(*ast->nodes.back(), yields)) {
+    if (!all_defers.empty()) {
+      std::set<const peg::Ast*> pre_loop_defers;
+      for (auto* stmt : p->pre_loop) {
+        auto* unwrapped = unwrap_stmt(stmt);
+        if (unwrapped->tag == "DEFER"_) pre_loop_defers.insert(unwrapped);
+      }
+      for (auto* d : all_defers) {
+        if (!pre_loop_defers.contains(d)) {
+          throw CulebraError(
+              "SyntaxError",
+              "defer in generator must be at the body's top level "
+              "(before the loop). Defers nested inside loop / if / match "
+              "bodies are not supported.",
+              static_cast<long>(d->line),
+              static_cast<long>(d->column));
+        }
+      }
+    }
     return transform_one_generator_fn_stage3(ast, src, src_len, name_ast,
                                              params_ast, *p, yields);
+  }
+  if (!all_defers.empty()) {
+    auto* d = all_defers.front();
+    throw CulebraError(
+        "SyntaxError",
+        "defer in generator requires a loop body (while or for-in). "
+        "Straight-line generators have no drain point to attach the "
+        "cleanup to.",
+        static_cast<long>(d->line),
+        static_cast<long>(d->column));
   }
   return transform_one_generator_fn_stage1(ast, src, src_len, name_ast, yields);
 }

--- a/include/generator_transform.h
+++ b/include/generator_transform.h
@@ -66,14 +66,29 @@ inline bool is_fn_boundary(unsigned int tag) {
   return tag == "FUNCTION"_ || tag == "LAMBDA"_ || tag == "MULTIFN_DECL"_;
 }
 
-// True if `node` carries at least one YIELD anywhere inside, stopping
-// at fn boundaries (see `is_fn_boundary`).
+// True if `node` carries at least one YIELD or YIELD_FROM anywhere
+// inside, stopping at fn boundaries (see `is_fn_boundary`). Treating
+// the two as equivalent here lets Stage 5's for-in desugar fire even
+// when the only yield-shaped node inside is a `yield from`.
 inline bool fn_body_has_yield(const peg::Ast& node) {
   using namespace peg::udl;
-  if (node.tag == "YIELD"_) return true;
+  if (node.tag == "YIELD"_ || node.tag == "YIELD_FROM"_) return true;
   if (is_fn_boundary(node.tag)) return false;
   for (auto& c : node.nodes) {
     if (fn_body_has_yield(*c)) return true;
+  }
+  return false;
+}
+
+// True if `node` has at least one YIELD_FROM. The dispatcher uses this
+// to route bodies with delegation through the Stage 6b phase machine
+// instead of the Stage 3 verbatim-while codegen.
+inline bool body_has_yield_from(const peg::Ast& node) {
+  using namespace peg::udl;
+  if (node.tag == "YIELD_FROM"_) return true;
+  if (is_fn_boundary(node.tag)) return false;
+  for (auto& c : node.nodes) {
+    if (body_has_yield_from(*c)) return true;
   }
   return false;
 }
@@ -523,6 +538,38 @@ inline std::string substitute_yields_in_stmt(
   return out;
 }
 
+// Wire the generated class's `new(_p0, _p1, ...)` slot list and append
+// matching `this.<param> = _pN` initializers, then `this.<local> = nil`
+// for every body-declared local not shadowed by a param. Shared between
+// Stage 3 and Stage 6b — both stages seed `ctor_inits` with their own
+// state-field prefix (`_g_drained` / `_g_phase` / etc.) before calling
+// this to append the per-instance bindings.
+inline void emit_ctor_param_and_local_inits(
+    const std::vector<std::string_view>& param_names,
+    const std::set<std::string>& locals,
+    std::string& ctor_params,
+    std::string& ctor_call_args,
+    std::string& ctor_inits) {
+  std::set<std::string> param_set;
+  for (size_t j = 0; j < param_names.size(); j++) {
+    auto pn = std::string(param_names[j]);
+    auto slot = std::format("_p{}", j);
+    if (j > 0) {
+      ctor_params += ", ";
+      ctor_call_args += ", ";
+    }
+    ctor_params += slot;
+    ctor_call_args += pn;
+    ctor_inits += std::format("      this.{} = {}\n", pn, slot);
+    param_set.insert(std::move(pn));
+  }
+  for (const auto& l : locals) {
+    if (!param_set.contains(l)) {
+      ctor_inits += std::format("      this.{} = nil\n", l);
+    }
+  }
+}
+
 // Split pre-loop into (a) the non-defer statements (kept inline) and
 // (b) the LIFO-ordered defer bodies (lifted into the generator's
 // `dispose()` method directly, inlined rather than wrapped in
@@ -602,24 +649,8 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage3(
       "      this._g_la = nil\n"
       "      this._g_inited = false\n"
       "      this._g_disposed = false\n";
-  std::set<std::string> param_set;
-  for (size_t j = 0; j < param_names.size(); j++) {
-    auto pn = std::string(param_names[j]);
-    auto slot = std::format("_p{}", j);
-    if (j > 0) {
-      ctor_params += ", ";
-      ctor_call_args += ", ";
-    }
-    ctor_params += slot;
-    ctor_call_args += pn;
-    ctor_inits += std::format("      this.{} = {}\n", pn, slot);
-    param_set.insert(std::move(pn));
-  }
-  for (const auto& l : locals) {
-    if (!param_set.contains(l)) {
-      ctor_inits += std::format("      this.{} = nil\n", l);
-    }
-  }
+  emit_ctor_param_and_local_inits(param_names, locals,
+                                  ctor_params, ctor_call_args, ctor_inits);
 
   // Rewrite each body fragment to use `this.X` for params + locals.
   // pre_loop walks statements one by one so DEFER nodes can be lifted
@@ -693,14 +724,223 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage3(
   return ast;
 }
 
+// --- Stage 6b: yield from via phase machine ------------------------------
+
+// WHILE body acceptable by Stage 6b: zero or more leading statements
+// (typically `let x = _g_it.next()` after Stage 5 desugar) followed by
+// a single YIELD or YIELD_FROM as the final stmt. Bodies with multiple
+// yields, branches, or yield-from nested deeper than top level are
+// rejected — Stage 6b falls back to the dispatcher's error path so the
+// user gets a clean SyntaxError instead of silent miscompilation.
+struct While6bBody {
+  std::vector<const peg::Ast*> pre_stmts;
+  const peg::Ast* yield_node;  // YIELD or YIELD_FROM
+  bool is_yield_from;
+};
+
+inline std::optional<While6bBody> analyze_while_body_for_stage6b(
+    const peg::Ast& while_node) {
+  using namespace peg::udl;
+  if (while_node.nodes.size() < 2) return std::nullopt;
+  const auto& body = *while_node.nodes[1];
+  auto stmts = body_stmts(body);
+  While6bBody result;
+  for (size_t i = 0; i < stmts.size(); i++) {
+    auto* u = unwrap_stmt(stmts[i]);
+    if (u->tag == "YIELD"_ || u->tag == "YIELD_FROM"_) {
+      if (i + 1 != stmts.size()) return std::nullopt;
+      result.yield_node = u;
+      result.is_yield_from = (u->tag == "YIELD_FROM"_);
+      return result;
+    }
+    // Reject nested yields inside non-terminal stmts.
+    if (fn_body_has_yield(*stmts[i])) return std::nullopt;
+    result.pre_stmts.push_back(stmts[i]);
+  }
+  return std::nullopt;
+}
+
+// Emit the body of a single phase block of has_next(), with locals
+// rewritten via `rewrite_locals_to_this`. Each phase ends with either
+// `return true` (yielded a value), `continue` (state advanced, restart
+// the dispatch loop), or `return false` (drained).
+inline std::string emit_stage6b_phase_block(
+    int next_phase, const peg::Ast& stmt,
+    const char* src, size_t src_len,
+    const std::set<std::string>& rewrite_set) {
+  using namespace peg::udl;
+  auto* u = unwrap_stmt(&stmt);
+  if (u->tag == "YIELD"_ && !u->nodes.empty()) {
+    auto expr = rewrite_locals_to_this(
+        ast_source_slice(*u->nodes[0], src, src_len), rewrite_set);
+    return std::format(
+        "        this._g_la = ({0})\n"
+        "        this._g_has_la = true\n"
+        "        this._g_phase = {1}\n"
+        "        return true\n",
+        expr, next_phase);
+  }
+  if (u->tag == "YIELD_FROM"_ && !u->nodes.empty()) {
+    auto expr = rewrite_locals_to_this(
+        ast_source_slice(*u->nodes[0], src, src_len), rewrite_set);
+    return std::format(
+        "        this._g_delegate = ({0}).iter()\n"
+        "        this._g_phase = {1}\n"
+        "        continue\n",
+        expr, next_phase);
+  }
+  if (u->tag == "WHILE"_) {
+    auto wb = analyze_while_body_for_stage6b(*u);
+    if (!wb) return {};
+    auto cond = rewrite_locals_to_this(
+        ast_source_slice(*u->nodes[0], src, src_len), rewrite_set);
+    std::string pre;
+    for (auto* s : wb->pre_stmts) {
+      pre += "          ";
+      pre += rewrite_locals_to_this(
+          ast_source_slice(*s, src, src_len), rewrite_set);
+      pre += "\n";
+    }
+    auto yexpr = rewrite_locals_to_this(
+        ast_source_slice(*wb->yield_node->nodes[0], src, src_len), rewrite_set);
+    std::string yield_part;
+    if (wb->is_yield_from) {
+      yield_part = std::format(
+          "          this._g_delegate = ({0}).iter()\n"
+          "          continue\n",
+          yexpr);
+    } else {
+      yield_part = std::format(
+          "          this._g_la = ({0})\n"
+          "          this._g_has_la = true\n"
+          "          return true\n",
+          yexpr);
+    }
+    return std::format(
+        "        if {0} {{\n"
+        "{1}"
+        "{2}"
+        "        }} else {{\n"
+        "          this._g_phase = {3}\n"
+        "          continue\n"
+        "        }}\n",
+        cond, pre, yield_part, next_phase);
+  }
+  // Plain statement: execute verbatim (with locals rewritten) and advance.
+  auto stmt_rw = rewrite_locals_to_this(
+      ast_source_slice(stmt, src, src_len), rewrite_set);
+  return std::format(
+      "        {0}\n"
+      "        this._g_phase = {1}\n"
+      "        continue\n",
+      stmt_rw, next_phase);
+}
+
+inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage6b(
+    std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len,
+    const peg::Ast& name_ast,
+    const peg::Ast& params_ast) {
+  using namespace peg::udl;
+  auto gen_name = std::format("_Gen_{}_{}_{}",
+                              std::string(name_ast.token),
+                              name_ast.line, name_ast.column);
+
+  std::vector<std::string_view> param_names;
+  for (const auto& pn : params_ast.nodes) {
+    if (is_kw_only_sep(*pn) || is_kwargs_rest(*pn)) continue;
+    param_names.push_back(view_parameter(*pn).name);
+  }
+  auto locals = collect_local_names(*ast->nodes.back());
+  std::set<std::string> rewrite_set = locals;
+  for (auto& pn : param_names) rewrite_set.insert(std::string(pn));
+
+  std::string ctor_params;
+  std::string ctor_call_args;
+  std::string ctor_inits =
+      "      this._g_drained = false\n"
+      "      this._g_has_la = false\n"
+      "      this._g_la = nil\n"
+      "      this._g_disposed = false\n"
+      "      this._g_delegate = nil\n"
+      "      this._g_phase = 0\n";
+  emit_ctor_param_and_local_inits(param_names, locals,
+                                  ctor_params, ctor_call_args, ctor_inits);
+
+  // Walk top-level body statements and build phase blocks. Last phase
+  // is the synthetic "drained" terminator so each real phase can hand
+  // off to its successor with a simple ++index.
+  auto top_stmts = body_stmts(*ast->nodes.back());
+  std::string phases_src;
+  int phase_idx = 0;
+  for (auto* stmt : top_stmts) {
+    auto block = emit_stage6b_phase_block(phase_idx + 1,
+                                          *stmt, src, src_len, rewrite_set);
+    if (block.empty()) return ast;  // unsupported shape — caller will report
+    phases_src += std::format("      if this._g_phase == {} {{\n{}      }}\n",
+                              phase_idx, block);
+    phase_idx++;
+  }
+  // Terminator phase.
+  phases_src += std::format(
+      "      if this._g_phase == {} {{\n"
+      "        this._g_drained = true\n"
+      "        return false\n"
+      "      }}\n",
+      phase_idx);
+
+  auto synthesized = std::make_shared<std::string>(std::format(
+      "fn __gen_wrapper__() {{\n"
+      "  class {0} {{\n"
+      "    new({1}) {{\n{2}    }}\n"
+      "    iter() {{ this }}\n"
+      "    has_next() {{\n"
+      "      while true {{\n"
+      "        if this._g_drained {{ return false }}\n"
+      "        if this._g_has_la {{ return true }}\n"
+      "        if this._g_delegate != nil {{\n"
+      "          if this._g_delegate.has_next() {{\n"
+      "            this._g_la = this._g_delegate.next()\n"
+      "            this._g_has_la = true\n"
+      "            return true\n"
+      "          }}\n"
+      "          if this._g_delegate.has('dispose') {{ this._g_delegate.dispose() }}\n"
+      "          this._g_delegate = nil\n"
+      "        }}\n"
+      "{3}"
+      "      }}\n"
+      "    }}\n"
+      "    next() {{\n"
+      "      if !this._g_has_la {{ this.has_next() }}\n"
+      "      let _v = this._g_la\n"
+      "      this._g_la = nil\n"
+      "      this._g_has_la = false\n"
+      "      return _v\n"
+      "    }}\n"
+      "    dispose() {{\n"
+      "      if this._g_disposed {{ return nil }}\n"
+      "      this._g_disposed = true\n"
+      "      this._g_drained = true\n"
+      "      if this._g_delegate != nil {{\n"
+      "        if this._g_delegate.has('dispose') {{ this._g_delegate.dispose() }}\n"
+      "        this._g_delegate = nil\n"
+      "      }}\n"
+      "    }}\n"
+      "  }}\n"
+      "  {0}.new({4})\n"
+      "}}\n",
+      gen_name, ctor_params, ctor_inits, phases_src, ctor_call_args));
+  swap_body_from_wrapper(ast, synthesized);
+  return ast;
+}
+
 // Dispatcher: pattern-match the body and route to the right stage.
 // Stage 5 runs first as a source-level pre-pass that rewrites yielding
 // `for-in` loops into `while + iterator` form, then Stage 3 handles the
-// result. Stage 3 is the primary backend — its pattern is a superset of
-// Stage 2's (which has been folded in) and handles any while-bound
-// generator whose yields all live in one statement. Falls back to
-// Stage 1's eager-eval path for straight-line bodies whose yield
-// expressions don't reference loop-mutated locals.
+// result. Stage 6b takes any body containing `yield from` and emits a
+// phase machine instead. Stage 3 (verbatim while-preserve) is the
+// primary backend for plain yield generators; Stage 1's eager-eval path
+// catches straight-line bodies whose yield expressions don't reference
+// loop-mutated locals.
 inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
     std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len) {
   using namespace peg::udl;
@@ -708,7 +948,8 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
   while (i < ast->nodes.size() && ast->nodes[i]->tag == "DECORATOR"_) i++;
   if (i + 2 >= ast->nodes.size()) return ast;
   auto yields = collect_yields(*ast->nodes.back());
-  if (yields.empty()) return ast;
+  bool has_yf = body_has_yield_from(*ast->nodes.back());
+  if (yields.empty() && !has_yf) return ast;
 
   // C# rule (CS1626): a yield statement may not appear inside a try-catch
   // or defer block. The state-machine cost of supporting yield-spanning
@@ -739,7 +980,8 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
     src = desugared->data();
     src_len = desugared->size();
     yields = collect_yields(*ast->nodes.back());
-    if (yields.empty()) return ast;
+    has_yf = body_has_yield_from(*ast->nodes.back());
+    if (yields.empty() && !has_yf) return ast;
   }
 
   // Stage 6a defer scope: only top-level `defer { ... }` in the body is
@@ -750,6 +992,30 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
   auto all_defers = collect_defers(*ast->nodes.back());
   const auto& name_ast = *ast->nodes[i];
   const auto& params_ast = *ast->nodes[i + 1];
+
+  // Stage 6b: any body containing `yield from` goes through the phase
+  // machine codegen instead of Stage 3's verbatim while-preserve. The
+  // transformer leaves the body untouched when it can't pattern-match
+  // the shape; surface that as a SyntaxError so the user gets a clear
+  // failure mode rather than silent fallthrough to Stage 1.
+  if (has_yf) {
+    auto orig_body = ast->nodes.back();
+    auto out = transform_one_generator_fn_stage6b(ast, src, src_len,
+                                                   name_ast, params_ast);
+    if (out->nodes.back().get() == orig_body.get()) {
+      throw CulebraError(
+          "SyntaxError",
+          "yield from is only supported in the Stage 6b minimum scope: "
+          "linear sequence of yield / yield from at body top level, "
+          "optionally with a single trailing for-in / while whose body "
+          "is a single yield or yield from. Nested / branching "
+          "delegation is not yet supported.",
+          static_cast<long>(name_ast.line),
+          static_cast<long>(name_ast.column));
+    }
+    return out;
+  }
+
   if (auto p = match_stage3_pattern(*ast->nodes.back(), yields)) {
     if (!all_defers.empty()) {
       std::set<const peg::Ast*> pre_loop_defers;

--- a/include/generator_transform.h
+++ b/include/generator_transform.h
@@ -114,6 +114,16 @@ inline std::string ast_source_range(const std::vector<const peg::Ast*>& stmts,
   return std::string(src + first, last_end - first);
 }
 
+// Drop the enclosing `{` / `}` from a BLOCK source slice. A BLOCK that's
+// been parsed will always be wrapped in braces, but the check stays
+// defensive in case the slice is already brace-stripped or empty.
+inline std::string_view strip_block_braces(std::string_view s) {
+  if (s.size() >= 2 && s.front() == '{' && s.back() == '}') {
+    return s.substr(1, s.size() - 2);
+  }
+  return s;
+}
+
 // Rewrite every `\b<name>\b` in `src` to `this.<name>` for each name in
 // `names`, then strip `let `/`mut ` prefixes that now sit in front of
 // `this.X` (assignment, no longer declaration). Stage 2 spike uses a
@@ -259,19 +269,83 @@ inline std::optional<Stage3Pattern> match_stage3_pattern(
   return p;
 }
 
+// --- Stage 5: for-in desugar to while + iterator -------------------------
+
+// Outermost FOR nodes (within a single fn) that contain at least one YIELD
+// somewhere in their subtree. Stops at fn boundaries and does NOT descend
+// into yielding FORs — those are rewritten as a unit, so any inner FOR
+// nested within them is left alone for a follow-up pass. The walker only
+// surfaces FORs whose yields belong to *this* generator.
+inline std::vector<const peg::Ast*> collect_outermost_yielding_fors(
+    const peg::Ast& body) {
+  using namespace peg::udl;
+  std::vector<const peg::Ast*> out;
+  std::function<void(const peg::Ast&)> walk = [&](const peg::Ast& n) {
+    if (is_fn_boundary(n.tag)) return;
+    if (n.tag == "FOR"_ && fn_body_has_yield(n)) {
+      out.push_back(&n);
+      return;
+    }
+    for (auto& c : n.nodes) walk(*c);
+  };
+  walk(body);
+  return out;
+}
+
+// Source-level rewrite: each outermost yielding `for x in expr BODY` becomes
+// `let _g_it_<pos> = (expr).iter()
+//  while _g_it_<pos>.has_next() {
+//    let x = _g_it_<pos>.next()
+//    BODY_inner
+//  }`
+// Returns the rewritten body source, or `nullopt` when there were no
+// yielding FORs to rewrite (so callers can gate the desugar pipeline on a
+// single walk). Iterator variable names use the FOR's source position to
+// stay unique. The result has fresh source positions once re-parsed;
+// callers must re-parse before walking the AST again.
+inline std::optional<std::string> rewrite_yielding_fors_to_while(
+    const peg::Ast& body, const char* src, size_t src_len) {
+  auto fors = collect_outermost_yielding_fors(body);
+  if (fors.empty()) return std::nullopt;
+  std::string out(ast_source_slice(body, src, src_len));
+  size_t base = body.position;
+  for (auto it = fors.rbegin(); it != fors.rend(); ++it) {
+    auto* f = *it;
+    if (f->nodes.size() < 3) continue;
+    const auto& var_node = *f->nodes[0];
+    const auto& expr_node = *f->nodes[1];
+    const auto& blk_node = *f->nodes[2];
+    auto expr_sv = ast_source_slice(expr_node, src, src_len);
+    auto blk_inner = strip_block_braces(
+        ast_source_slice(blk_node, src, src_len));
+    auto iter_var = std::format("_g_it_{}", f->position);
+    auto replacement = std::format(
+        "let {0} = ({1}).iter()\n"
+        "while {0}.has_next() {{\n"
+        "  let {2} = {0}.next()\n"
+        "  {3}\n"
+        "}}",
+        iter_var, std::string(expr_sv),
+        std::string(var_node.token), std::string(blk_inner));
+    out.replace(f->position - base, f->length, replacement);
+  }
+  return out;
+}
+
 // --- Transformation entry points -----------------------------------------
 
-// Replace `ast->nodes.back()` (the original body BLOCK) with the BLOCK
-// from a freshly-parsed `fn __gen_wrapper__() { ... }` source fragment.
-// Shared by Stage 1 and Stage 2 — both end with "now swap the body".
-inline bool swap_body_from_wrapper(std::shared_ptr<peg::Ast> ast,
-                                   std::shared_ptr<std::string> synthesized) {
+// Re-parse a `fn __gen_wrapper__(...) { ... }` source fragment and return
+// its MULTIFN_DECL node, after registering the source for lifetime. peg::Ast
+// holds string_views into the source, so the synthesized buffer must stay
+// alive until the AST is discarded — generator_transform_sources() owns it.
+inline std::shared_ptr<peg::Ast> parse_wrapper_fn(
+    std::shared_ptr<std::string> synthesized) {
   using namespace peg::udl;
   generator_transform_sources().push_back(synthesized);
   std::vector<std::string> msgs;
   auto sub_ast = parse("<generator-transform>", synthesized->data(),
                        synthesized->size(), msgs);
-  if (!sub_ast) return false;
+  if (!sub_ast) return nullptr;
   std::shared_ptr<peg::Ast> wrapper_fn;
   std::function<void(std::shared_ptr<peg::Ast>)> walk =
       [&](std::shared_ptr<peg::Ast> n) {
@@ -280,7 +354,33 @@ inline bool swap_body_from_wrapper(std::shared_ptr<peg::Ast> ast,
         for (auto& c : n->nodes) walk(c);
       };
   walk(sub_ast);
+  return wrapper_fn;
+}
+
+// Replace `ast->nodes.back()` (the original body BLOCK) with the BLOCK
+// from a freshly-parsed `fn __gen_wrapper__() { ... }` source fragment.
+// Shared by Stage 1 and Stage 2 — both end with "now swap the body".
+inline bool swap_body_from_wrapper(std::shared_ptr<peg::Ast> ast,
+                                   std::shared_ptr<std::string> synthesized) {
+  auto wrapper_fn = parse_wrapper_fn(synthesized);
   if (!wrapper_fn) return false;
+  ast->nodes.back() = wrapper_fn->nodes.back();
+  return true;
+}
+
+// Replace `ast`'s PARAMETERS (at `params_idx`) and body with those from a
+// freshly-parsed `fn __gen_wrapper__(<params>) { <body> }` source. Keeps the
+// original name (and decorators) intact, while giving downstream stages an
+// AST whose param + body positions point into the synthesized source — the
+// shape Stage 3 needs after the Stage 5 for-in desugar rewrites the body.
+inline bool swap_body_with_wrapper_params(
+    std::shared_ptr<peg::Ast> ast,
+    std::shared_ptr<std::string> synthesized,
+    size_t params_idx) {
+  auto wrapper_fn = parse_wrapper_fn(synthesized);
+  if (!wrapper_fn || wrapper_fn->nodes.size() < 3) return false;
+  if (ast->nodes.size() <= params_idx + 1) return false;
+  ast->nodes[params_idx + 1] = wrapper_fn->nodes[1];
   ast->nodes.back() = wrapper_fn->nodes.back();
   return true;
 }
@@ -486,23 +586,41 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage3(
 }
 
 // Dispatcher: pattern-match the body and route to the right stage.
-// Stage 3 gets priority — its pattern is a superset of Stage 2's (which
-// has been folded in) and handles any while-bound generator whose
-// yields all live in one statement. Falls back to Stage 1's eager-eval
-// path for straight-line bodies whose yield expressions don't reference
-// loop-mutated locals.
+// Stage 5 runs first as a source-level pre-pass that rewrites yielding
+// `for-in` loops into `while + iterator` form, then Stage 3 handles the
+// result. Stage 3 is the primary backend — its pattern is a superset of
+// Stage 2's (which has been folded in) and handles any while-bound
+// generator whose yields all live in one statement. Falls back to
+// Stage 1's eager-eval path for straight-line bodies whose yield
+// expressions don't reference loop-mutated locals.
 inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
     std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len) {
   using namespace peg::udl;
   size_t i = 0;
   while (i < ast->nodes.size() && ast->nodes[i]->tag == "DECORATOR"_) i++;
   if (i + 2 >= ast->nodes.size()) return ast;
+  auto yields = collect_yields(*ast->nodes.back());
+  if (yields.empty()) return ast;
+
+  // Stage 5: rewrite yielding for-in loops to while + iterator at source
+  // level, then re-parse so Stage 3 picks them up.
+  if (auto rewritten = rewrite_yielding_fors_to_while(
+          *ast->nodes.back(), src, src_len)) {
+    auto params_sv = ast_source_slice(*ast->nodes[i + 1], src, src_len);
+    auto body_inner = strip_block_braces(*rewritten);
+    auto desugared = std::make_shared<std::string>(std::format(
+        "fn __gen_wrapper__{} {{\n{}\n}}\n",
+        std::string(params_sv), std::string(body_inner)));
+    if (!swap_body_with_wrapper_params(ast, desugared, i)) return ast;
+    src = desugared->data();
+    src_len = desugared->size();
+    yields = collect_yields(*ast->nodes.back());
+    if (yields.empty()) return ast;
+  }
+
   const auto& name_ast = *ast->nodes[i];
   const auto& params_ast = *ast->nodes[i + 1];
-  auto& body_slot = ast->nodes.back();
-  auto yields = collect_yields(*body_slot);
-  if (yields.empty()) return ast;
-  if (auto p = match_stage3_pattern(*body_slot, yields)) {
+  if (auto p = match_stage3_pattern(*ast->nodes.back(), yields)) {
     return transform_one_generator_fn_stage3(ast, src, src_len, name_ast,
                                              params_ast, *p, yields);
   }

--- a/include/generator_transform.h
+++ b/include/generator_transform.h
@@ -344,18 +344,9 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage1(
 // are processed back-to-front so earlier positions stay valid as later
 // replacements shift the tail. `yields` must be in source order and
 // every yield must lie inside the stmt range (caller guarantees).
-//
-// The replacement is wrapped in braces because of a cpp-peglib quirk:
-// when a single-stmt BLOCK collapses (BLOCK→STATEMENTS→STATEMENT→YIELD,
-// each with one child), the surviving YIELD-tagged node inherits the
-// outer BLOCK's position+length, so `y->length` may cover `{ yield expr
-// }` rather than just `yield expr`. `no_ast_opt` on YIELD doesn't help
-// — peglib's collapse rewrites position+length unconditionally when the
-// *outer* rule is the one being optimized away (see AstBase ctor at
-// peglib.h:5136 and AstOptimizer::optimize at peglib.h:5223). Wrapping
-// the replacement in braces restores a valid block where it was needed
-// and creates a harmless nested block in multi-stmt loop bodies — the
-// inner `return true` exits has_next() before any trailing code runs.
+// YIELD carries `{ no_ast_opt }` so its position+length survives AST
+// collapse exactly — the replacement maps `yield expr` 1:1 with no
+// outer-block padding needed.
 inline std::string substitute_yields_in_stmt(
     std::string_view stmt_src, size_t base_pos,
     const std::vector<const peg::Ast*>& yields,
@@ -370,7 +361,7 @@ inline std::string substitute_yields_in_stmt(
     size_t local_pos = y->position - base_pos;
     auto yexpr_sv = ast_source_slice(*y->nodes[0], src, src_len);
     auto replacement = std::format(
-        "{{ this._g_la = ({}); this._g_has_la = true; return true }}",
+        "this._g_la = ({}); this._g_has_la = true; return true",
         std::string(yexpr_sv));
     out.replace(local_pos, y->length, replacement);
   }

--- a/include/generator_transform.h
+++ b/include/generator_transform.h
@@ -1,34 +1,27 @@
 // Generator (yield) AST transformation pass.
 //
-// Stage 0 (yield 構文 + 1 yield 直線 body): re-parse-based source
-// synthesis. A `fn name(...) { yield expr }` is rewritten to:
+// A `fn` whose body contains `yield` / `yield from` is rewritten, at
+// parse time, into an anonymous class implementing the Iterator
+// protocol (iter / has_next / next / dispose), then re-parsed — the
+// interp / JIT / AOT runtimes execute the synthesized class with no
+// generator-specific support of their own.
 //
+//   fn name(...) { ... yield ... }
+//     ->
 //   fn name(...) {
-//     class _Gen_<name>_<line>_<col> {
-//       new(_y) { this.phase = 0; this._y = _y }
-//       iter() { this }
-//       has_next() { this.phase != 1 }
-//       next() {
-//         if this.phase == 0 {
-//           this.phase = 1
-//           return this._y
-//         }
-//         return nil
-//       }
-//     }
-//     _Gen_<name>_<line>_<col>.new(<original yield expr>)
+//     class _Gen_<name>_<line>_<col> { new(...) {...} iter()/has_next()/
+//                                      next()/dispose() }
+//     _Gen_<name>_<line>_<col>.new(...)
 //   }
 //
-// Stage 0 cheats by evaluating the yield expression eagerly and
-// passing it to the synthesized class's constructor — fine for the
-// single-yield case, replaced in Stage 1 by a real state machine
-// dispatch over phases. Stage 2 added while-loop bodies with a direct
-// yield; Stage 3 generalizes it so the yield can live inside an
-// IF/ELSE/MATCH branch of the loop body.
-//
-// See [[project-generator-design]] for the 5 core design axes
-// (anonymous class / pure transformation / Phase 2 protocol /
-// source-location propagation / all-locals-on-heap).
+// The body is lowered by a flat-dispatch CPS state machine (see
+// `CpsBuilder`): each basic block becomes a state, control flow becomes
+// `this._g_state = K; continue` jumps over one `while true` dispatch
+// loop, and every local lives on the instance (all-locals-on-heap, so no
+// liveness analysis). Two source-level pre-passes run first: the C# rule
+// rejects yield inside try-catch/defer, and yielding for-in loops are
+// desugared to `while it.has_next()` form. See
+// [[project-generator-design]] for the design axes and the frozen spec.
 
 #pragma once
 
@@ -76,19 +69,6 @@ inline bool fn_body_has_yield(const peg::Ast& node) {
   if (is_fn_boundary(node.tag)) return false;
   for (auto& c : node.nodes) {
     if (fn_body_has_yield(*c)) return true;
-  }
-  return false;
-}
-
-// True if `node` has at least one YIELD_FROM. The dispatcher uses this
-// to route bodies with delegation through the Stage 6b phase machine
-// instead of the Stage 3 verbatim-while codegen.
-inline bool body_has_yield_from(const peg::Ast& node) {
-  using namespace peg::udl;
-  if (node.tag == "YIELD_FROM"_) return true;
-  if (is_fn_boundary(node.tag)) return false;
-  for (auto& c : node.nodes) {
-    if (body_has_yield_from(*c)) return true;
   }
   return false;
 }
@@ -144,20 +124,6 @@ inline const peg::Ast* find_yield_inside_try_or_defer(const peg::Ast& body) {
   return found;
 }
 
-// Collect every YIELD inside a fn body in source order, stopping at
-// inner fn boundaries (same rule as `fn_body_has_yield`).
-inline std::vector<const peg::Ast*> collect_yields(const peg::Ast& node) {
-  std::vector<const peg::Ast*> out;
-  std::function<void(const peg::Ast&)> walk = [&](const peg::Ast& n) {
-    using namespace peg::udl;
-    if (n.tag == "YIELD"_) { out.push_back(&n); return; }
-    if (is_fn_boundary(n.tag)) return;
-    for (auto& c : n.nodes) walk(*c);
-  };
-  walk(node);
-  return out;
-}
-
 // Slice the source range an AST node spans. peg::Ast carries
 // `position` + `length` in bytes; safe so long as `src` is the same
 // buffer that produced `node`.
@@ -168,17 +134,6 @@ inline std::string_view ast_source_slice(const peg::Ast& node,
 }
 
 // --- Source-text helpers -------------------------------------------------
-
-// Concatenated source range covering a contiguous slice of AST nodes
-// (whitespace + comments between them included). Empty list → "".
-inline std::string ast_source_range(const std::vector<const peg::Ast*>& stmts,
-                                     const char* src, size_t src_len) {
-  if (stmts.empty()) return "";
-  auto first = stmts.front()->position;
-  auto last_end = stmts.back()->position + stmts.back()->length;
-  if (last_end > src_len) return "";
-  return std::string(src + first, last_end - first);
-}
 
 // Drop the enclosing `{` / `}` from a BLOCK source slice. A BLOCK that's
 // been parsed will always be wrapped in braces, but the check stays
@@ -246,19 +201,6 @@ inline std::set<std::string> collect_local_names(const peg::Ast& body) {
   return out;
 }
 
-// --- Stage 3 pattern: pre-loop init + while { pre-yield, yield-bearing stmt,
-// post-yield }. `yield_stmt` is one loop-body statement that may BE a yield
-// (Stage 2 case) or an IF/MATCH whose branches contain the yields. All yields
-// in the loop must live inside that one statement.
-
-struct Stage3Pattern {
-  std::vector<const peg::Ast*> pre_loop;
-  const peg::Ast* loop_cond;
-  std::vector<const peg::Ast*> pre_yield;
-  const peg::Ast* yield_stmt;
-  std::vector<const peg::Ast*> post_yield;
-};
-
 // Unwrap a STATEMENT wrapper down to the concrete tag (CLASS_DECL,
 // WHILE, ASSIGNMENT, ...). AstOptimizer collapses most STATEMENTs
 // already, but the wrapper survives for the choice-tagged variants.
@@ -281,66 +223,6 @@ inline std::vector<const peg::Ast*> body_stmts(const peg::Ast& body) {
     out.push_back(&body);
   }
   return out;
-}
-
-inline std::optional<Stage3Pattern> match_stage3_pattern(
-    const peg::Ast& body, const std::vector<const peg::Ast*>& yields) {
-  using namespace peg::udl;
-  if (yields.empty()) return std::nullopt;
-  auto stmts = body_stmts(body);
-  // Locate the WHILE among top-level body stmts.
-  size_t while_idx = stmts.size();
-  const peg::Ast* while_node = nullptr;
-  for (size_t i = 0; i < stmts.size(); i++) {
-    auto* s = unwrap_stmt(stmts[i]);
-    if (s->tag == "WHILE"_) {
-      if (while_node) return std::nullopt;  // multiple loops
-      while_node = s;
-      while_idx = i;
-    }
-  }
-  if (!while_node || while_node->nodes.size() < 2) return std::nullopt;
-  // Reject anything after the while (Stage 3 keeps the loop terminal).
-  if (while_idx + 1 != stmts.size()) return std::nullopt;
-  // Every yield must be inside the loop body, not in pre-loop stmts.
-  const peg::Ast* loop_body = while_node->nodes[1].get();
-  size_t lb_lo = loop_body->position;
-  size_t lb_hi = loop_body->position + loop_body->length;
-  for (auto* y : yields) {
-    if (y->position < lb_lo || y->position + y->length > lb_hi) {
-      return std::nullopt;
-    }
-  }
-  // All yields must live inside one loop-body statement (which may itself BE
-  // a yield, or an IF/MATCH containing them). yields are in source order, so
-  // the stmt containing yields[0] is the only possible candidate — anything
-  // straddling into a sibling stmt fails the pattern.
-  auto inner = body_stmts(*loop_body);
-  size_t yidx = inner.size();
-  for (size_t i = 0; i < inner.size(); i++) {
-    auto* s = inner[i];
-    size_t s_lo = s->position;
-    size_t s_hi = s->position + s->length;
-    if (yields[0]->position < s_lo ||
-        yields[0]->position + yields[0]->length > s_hi) continue;
-    for (auto* y : yields) {
-      if (y->position < s_lo || y->position + y->length > s_hi) {
-        return std::nullopt;
-      }
-    }
-    yidx = i;
-    break;
-  }
-  if (yidx == inner.size()) return std::nullopt;
-  Stage3Pattern p;
-  p.loop_cond = while_node->nodes[0].get();
-  for (size_t i = 0; i < while_idx; i++) p.pre_loop.push_back(stmts[i]);
-  for (size_t i = 0; i < yidx; i++) p.pre_yield.push_back(inner[i]);
-  p.yield_stmt = inner[yidx];
-  for (size_t i = yidx + 1; i < inner.size(); i++) {
-    p.post_yield.push_back(inner[i]);
-  }
-  return p;
 }
 
 // --- Stage 5: for-in desugar to while + iterator -------------------------
@@ -459,93 +341,6 @@ inline bool swap_body_with_wrapper_params(
   return true;
 }
 
-// Stage 1: yield expressions are eager-evaluated in the factory and
-// passed through positional ctor args `_y0, _y1, ...`. Works for any
-// body whose yields depend only on params/literals — see
-// [[project-generator-design]] §Stage 1. The class carries a no-op
-// `dispose()` so for-in's unconditional cleanup call lands on a real
-// method (the dispatcher already rejects Stage 1 bodies that try to
-// use `defer`, so there's nothing to actually run here).
-inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage1(
-    std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len,
-    const peg::Ast& name_ast,
-    const std::vector<const peg::Ast*>& yields) {
-  auto gen_name = std::format("_Gen_{}_{}_{}",
-                              std::string(name_ast.token),
-                              name_ast.line, name_ast.column);
-
-  std::string ctor_params;
-  std::string ctor_body_inits;
-  std::string ctor_call_args;
-  std::string arms;
-  for (size_t j = 0; j < yields.size(); j++) {
-    auto yexpr = ast_source_slice(*yields[j]->nodes[0], src, src_len);
-    if (yexpr.empty()) return ast;
-    auto slot = std::format("_y{}", j);
-    if (j > 0) {
-      ctor_params += ", ";
-      ctor_call_args += ", ";
-    }
-    ctor_params += slot;
-    ctor_call_args += std::string(yexpr);
-    ctor_body_inits += std::format("; this.{0} = {0}", slot);
-    arms += std::format(
-        "      if this.phase == {0} {{\n"
-        "        this.phase = {1}\n"
-        "        return this.{2}\n"
-        "      }}\n",
-        j, j + 1, slot);
-  }
-
-  auto synthesized = std::make_shared<std::string>(std::format(
-      "fn __gen_wrapper__() {{\n"
-      "  class {0} {{\n"
-      "    new({1}) {{ this.phase = 0{2} }}\n"
-      "    iter() {{ this }}\n"
-      "    has_next() {{ this.phase != {3} }}\n"
-      "    next() {{\n"
-      "{4}"
-      "      return nil\n"
-      "    }}\n"
-      "    dispose() {{}}\n"
-      "  }}\n"
-      "  {0}.new({5})\n"
-      "}}\n",
-      gen_name, ctor_params, ctor_body_inits,
-      yields.size(), arms, ctor_call_args));
-  swap_body_from_wrapper(ast, synthesized);
-  return ast;
-}
-
-// Substitute every YIELD inside `stmt_src` (a source slice starting at
-// absolute `base_pos`) with the lookahead-set-and-return inline. Yields
-// are processed back-to-front so earlier positions stay valid as later
-// replacements shift the tail. `yields` must be in source order and
-// every yield must lie inside the stmt range (caller guarantees).
-// YIELD carries `{ no_ast_opt }` so its position+length survives AST
-// collapse exactly — the replacement maps `yield expr` 1:1 with no
-// outer-block padding needed.
-inline std::string substitute_yields_in_stmt(
-    std::string_view stmt_src, size_t base_pos,
-    const std::vector<const peg::Ast*>& yields,
-    const char* src, size_t src_len) {
-  std::string out(stmt_src);
-  for (auto it = yields.rbegin(); it != yields.rend(); ++it) {
-    auto* y = *it;
-    if (y->position < base_pos ||
-        y->position + y->length > base_pos + stmt_src.size()) {
-      continue;
-    }
-    size_t local_pos = y->position - base_pos;
-    auto yexpr_sv = ast_source_slice(*y->nodes[0], src, src_len);
-    auto replacement = std::format(
-        "this._g_la = ({}); this._g_has_la = true; return true",
-        std::string(yexpr_sv));
-    out.replace(local_pos, y->length, replacement);
-  }
-  return out;
-}
-
 // Wire the generated class's `new(_p0, _p1, ...)` slot list and append
 // matching `this.<param> = _pN` initializers, then `this.<local> = nil`
 // for every body-declared local not shadowed by a param. Shared between
@@ -578,277 +373,220 @@ inline void emit_ctor_param_and_local_inits(
   }
 }
 
-// Split pre-loop into (a) the non-defer statements (kept inline) and
-// (b) the LIFO-ordered defer bodies (lifted into the generator's
-// `dispose()` method directly, inlined rather than wrapped in
-// closures). Inlining sidesteps a JIT limitation around `this` capture
-// in closures created from method bodies, and the closure indirection
-// wasn't doing anything Stage 6a's minimum scope needed anyway —
-// defers at body top level are unconditional, so reach + run are
-// equivalent. The dispose code is gated on `_g_inited` so a generator
-// disposed before any iteration doesn't fire defers whose locals
-// haven't been initialized yet.
-inline void split_pre_loop_stmts_and_defers(
-    const std::vector<const peg::Ast*>& stmts,
-    const char* src, size_t src_len,
-    const std::set<std::string>& rewrite_set,
-    std::string& out_stmts,
-    std::string& out_dispose_body) {
+// --- CPS engine: flat-dispatch state machine -----------------------------
+//
+// Linearizes a generator body into a flat list of states. Each state is a
+// culebra statement sequence ending in a transition: a yield (set
+// lookahead, advance state, `return true`), a delegate hand-off
+// (`yield from`), or a `this._g_state = K; continue` jump. has_next() is
+// one `while true` dispatch loop over the states. Because culebra's yield
+// is a STATEMENT (never an expression) and locals live on the heap
+// (this.X), the linearizer works statement-by-statement with no
+// expression splitting and no liveness analysis; "flat" dispatch (every
+// basic block is a state, edges set a counter) sidesteps the relooper
+// problem of reconstructing structured loops. See
+// [[project-generator-design]] §CPS.
+//
+// Handles plain stmts / yield / yield from / if-elseif-else / while
+// (incl. nested) / break / continue / return / defer. for-in is
+// desugared to while by an upstream pre-pass. A yielding `match` arm is
+// grammatically impossible (yield is a statement, match arms are
+// expressions), so match never carries a yield to lower.
+
+// True if `node` contains a break/continue that targets an *enclosing*
+// loop (i.e. not nested inside a while/for within `node`), or a return
+// anywhere. Such statements can't be emitted verbatim into the dispatch
+// loop — break/continue/return must become state jumps. A self-contained
+// inner loop with its own internal break stays verbatim-safe (the break
+// binds to that real inner loop). Stops at fn boundaries.
+inline bool has_escaping_loop_ctrl(const peg::Ast& node, int loop_depth = 0) {
   using namespace peg::udl;
+  if (is_fn_boundary(node.tag)) return false;
+  if (node.tag == "RETURN"_) return true;
+  if ((node.tag == "BREAK"_ || node.tag == "CONTINUE"_) && loop_depth == 0) {
+    return true;
+  }
+  int inner = (node.tag == "WHILE"_ || node.tag == "FOR"_) ? loop_depth + 1
+                                                           : loop_depth;
+  for (auto& c : node.nodes) {
+    if (has_escaping_loop_ctrl(*c, inner)) return true;
+  }
+  return false;
+}
+
+struct CpsBuilder {
+  const char* src;
+  size_t src_len;
+  const std::set<std::string>& rewrite_set;
+  std::vector<std::string> states;
+  int terminal = -1;  // state that sets drained + returns false
+  // (header, exit) of each enclosing CPS-managed loop, innermost last.
+  std::vector<std::pair<int, int>> loop_stack;
+  // `defer { B }` bodies, in source order. Each is registered (a
+  // `_g_defer_K` flag set true) when its state is reached and run at
+  // dispose in reverse (LIFO).
   std::vector<std::string> defer_bodies;
-  for (auto* stmt : stmts) {
-    auto* unwrapped = unwrap_stmt(stmt);
-    if (unwrapped->tag == "DEFER"_ && !unwrapped->nodes.empty()) {
-      auto block_sv = ast_source_slice(*unwrapped->nodes[0], src, src_len);
-      auto inner_sv = strip_block_braces(block_sv);
-      defer_bodies.push_back(rewrite_locals_to_this(inner_sv, rewrite_set));
-    } else {
-      auto stmt_sv = ast_source_slice(*stmt, src, src_len);
-      out_stmts += rewrite_locals_to_this(stmt_sv, rewrite_set);
-      out_stmts += "\n";
+  bool failed = false;
+
+  int fresh() {
+    states.emplace_back();
+    return static_cast<int>(states.size()) - 1;
+  }
+  std::string rw(const peg::Ast& n) {
+    return rewrite_locals_to_this(ast_source_slice(n, src, src_len),
+                                  rewrite_set);
+  }
+  // A fresh state that just jumps to `target` (break/continue/return).
+  int jump_state(int target) {
+    int e = fresh();
+    states[e] = std::format("      this._g_state = {}\n      continue\n",
+                            target);
+    return e;
+  }
+
+  // True if this statement needs structural compilation: it contains a
+  // yield anywhere, a break/continue/return escaping to an enclosing loop
+  // / the generator, or a defer (which must register into the dispose
+  // registry, not fire as a has_next-scope defer). Everything else is
+  // verbatim-safe.
+  static bool needs_split(const peg::Ast& s) {
+    return fn_body_has_yield(s) || has_escaping_loop_ctrl(s) ||
+           !collect_defers(s).empty();
+  }
+
+  // Linearize `stmts`, returning the entry state. `cont` is the state to
+  // jump to after the sequence completes. Maximal runs of yield-free
+  // statements collapse into a single state.
+  int compile_seq(const std::vector<const peg::Ast*>& stmts, int cont) {
+    int k = cont;
+    std::string pending;
+    auto flush = [&]() {
+      if (pending.empty()) return;
+      int s = fresh();
+      states[s] = pending +
+                  std::format("      this._g_state = {}\n      continue\n", k);
+      k = s;
+      pending.clear();
+    };
+    for (size_t idx = stmts.size(); idx-- > 0;) {
+      const peg::Ast* s = stmts[idx];
+      if (!needs_split(*s)) {
+        pending = "      " + rw(*s) + "\n" + pending;
+      } else {
+        flush();
+        k = compile_stmt(s, k);
+        if (failed) return -1;
+      }
     }
+    flush();
+    return k;
   }
-  // LIFO: last-registered defer runs first.
-  for (auto it = defer_bodies.rbegin(); it != defer_bodies.rend(); ++it) {
-    out_dispose_body += "        ";
-    out_dispose_body += *it;
-    out_dispose_body += "\n";
+
+  int compile_stmt(const peg::Ast* s, int cont) {
+    using namespace peg::udl;
+    auto* u = unwrap_stmt(s);
+    if (u->tag == "YIELD"_ && !u->nodes.empty()) {
+      int e = fresh();
+      states[e] = std::format(
+          "      this._g_la = ({})\n"
+          "      this._g_has_la = true\n"
+          "      this._g_state = {}\n"
+          "      return true\n",
+          rw(*u->nodes[0]), cont);
+      return e;
+    }
+    if (u->tag == "YIELD_FROM"_ && !u->nodes.empty()) {
+      int e = fresh();
+      states[e] = std::format(
+          "      this._g_delegate = ({}).iter()\n"
+          "      this._g_state = {}\n"
+          "      continue\n",
+          rw(*u->nodes[0]), cont);
+      return e;
+    }
+    if (u->tag == "BREAK"_) {
+      if (loop_stack.empty()) { failed = true; return -1; }
+      return jump_state(loop_stack.back().second);
+    }
+    if (u->tag == "CONTINUE"_) {
+      if (loop_stack.empty()) { failed = true; return -1; }
+      return jump_state(loop_stack.back().first);
+    }
+    if (u->tag == "RETURN"_) {
+      // Generators ignore a return value; `return` just ends iteration.
+      return jump_state(terminal);
+    }
+    if (u->tag == "DEFER"_ && !u->nodes.empty()) {
+      // Register the defer body when reached; dispose runs it (LIFO).
+      int k = static_cast<int>(defer_bodies.size());
+      defer_bodies.push_back(rewrite_locals_to_this(
+          strip_block_braces(ast_source_slice(*u->nodes[0], src, src_len)),
+          rewrite_set));
+      int e = fresh();
+      states[e] = std::format(
+          "      this._g_defer_{} = true\n      this._g_state = {}\n"
+          "      continue\n",
+          k, cont);
+      return e;
+    }
+    if (u->tag == "IF"_) return compile_if(u, cont);
+    if (u->tag == "WHILE"_ && u->nodes.size() >= 2) {
+      int h = fresh();
+      loop_stack.push_back({h, cont});
+      int body_entry = compile_seq(body_stmts(*u->nodes[1]), h);
+      loop_stack.pop_back();
+      if (failed) return -1;
+      states[h] = std::format(
+          "      if {} {{ this._g_state = {} }} else {{ this._g_state = {} }}\n"
+          "      continue\n",
+          rw(*u->nodes[0]), body_entry, cont);
+      return h;
+    }
+    if (u->tag == "LEXICAL_SCOPE"_ || u->tag == "STATEMENTS"_) {
+      return compile_seq(body_stmts(*u), cont);
+    }
+    failed = true;  // anything unexpected
+    return -1;
   }
-}
 
-// Stage 3: while-loop body whose yields all live inside one statement
-// (the yield-bearing stmt — may be a direct YIELD, an IF/ELSE, or a
-// MATCH). The loop is preserved verbatim in `has_next()` so iterations
-// that don't yield (e.g. filter_even's odd numbers) skip naturally. The
-// yield-bearing stmt's source is rewritten so each `yield expr` becomes
-// `this._g_la = (expr); this._g_has_la = true; return true` — control
-// re-enters `has_next()` on the next call and the top-of-method
-// post-yield block advances state past the returned yield. This
-// supersedes Stage 2 (single direct yield) — a Stage 2-shape body
-// matches Stage 3 with `yield_stmt = YIELD` and produces equivalent
-// behavior. See [[project-generator-design]] §Stage 3 設計詳細.
-inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage3(
-    std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len,
-    const peg::Ast& name_ast,
-    const peg::Ast& params_ast,
-    const Stage3Pattern& p,
-    const std::vector<const peg::Ast*>& yields) {
-  auto gen_name = std::format("_Gen_{}_{}_{}",
-                              std::string(name_ast.token),
-                              name_ast.line, name_ast.column);
-
-  std::vector<std::string_view> param_names;
-  for (const auto& pn : params_ast.nodes) {
-    if (is_kw_only_sep(*pn) || is_kwargs_rest(*pn)) continue;
-    param_names.push_back(view_parameter(*pn).name);
+  // if / else-if / else chain. IF nodes are [cond, block, cond, block, ...,
+  // elseblock?]; a trailing odd node is the bare `else` block.
+  int compile_if(const peg::Ast* ifnode, int cont) {
+    const auto& nodes = ifnode->nodes;
+    size_t n = nodes.size();
+    int else_entry;
+    size_t pairs;
+    if (n % 2 == 1) {
+      else_entry = compile_seq(body_stmts(*nodes[n - 1]), cont);
+      if (failed) return -1;
+      pairs = (n - 1) / 2;
+    } else {
+      else_entry = cont;
+      pairs = n / 2;
+    }
+    int chain = else_entry;
+    for (size_t p = pairs; p-- > 0;) {
+      int block_entry = compile_seq(body_stmts(*nodes[2 * p + 1]), cont);
+      if (failed) return -1;
+      int s = fresh();
+      states[s] = std::format(
+          "      if {} {{ this._g_state = {} }} else {{ this._g_state = {} }}\n"
+          "      continue\n",
+          rw(*nodes[2 * p]), block_entry, chain);
+      chain = s;
+    }
+    return chain;
   }
-  auto locals = collect_local_names(*ast->nodes.back());
-  std::set<std::string> rewrite_set = locals;
-  for (auto& pn : param_names) rewrite_set.insert(std::string(pn));
-
-  // Ctor takes `_p0, _p1, ...` (off the user namespace to avoid
-  // culebra's cross-fn shadow check) and stores them under the
-  // original parameter names.
-  std::string ctor_params;
-  std::string ctor_call_args;
-  std::string ctor_inits =
-      "      this._g_drained = false\n"
-      "      this._g_has_la = false\n"
-      "      this._g_la = nil\n"
-      "      this._g_inited = false\n"
-      "      this._g_disposed = false\n";
-  emit_ctor_param_and_local_inits(param_names, locals,
-                                  ctor_params, ctor_call_args, ctor_inits);
-
-  // Rewrite each body fragment to use `this.X` for params + locals.
-  // pre_loop walks statements one by one so DEFER nodes can be lifted
-  // into the dispose method directly (inlined, not wrapped in closures
-  // — JIT can't capture `this` through a method-local closure today).
-  std::string pre_loop_src;
-  std::string dispose_body_src;
-  split_pre_loop_stmts_and_defers(
-      p.pre_loop, src, src_len, rewrite_set,
-      pre_loop_src, dispose_body_src);
-  auto pre_yield_src = rewrite_locals_to_this(
-      ast_source_range(p.pre_yield, src, src_len), rewrite_set);
-  auto post_yield_src = rewrite_locals_to_this(
-      ast_source_range(p.post_yield, src, src_len), rewrite_set);
-  auto cond_src = rewrite_locals_to_this(
-      ast_source_slice(*p.loop_cond, src, src_len), rewrite_set);
-
-  // Yield-bearing stmt: substitute each yield first (positions valid),
-  // then rewrite locals to `this.X`.
-  auto yield_stmt_sv = ast_source_slice(*p.yield_stmt, src, src_len);
-  auto yield_stmt_substituted = substitute_yields_in_stmt(
-      yield_stmt_sv, p.yield_stmt->position, yields, src, src_len);
-  auto yield_stmt_src = rewrite_locals_to_this(yield_stmt_substituted,
-                                                rewrite_set);
-
-  auto synthesized = std::make_shared<std::string>(std::format(
-      "fn __gen_wrapper__() {{\n"
-      "  class {0} {{\n"
-      "    new({1}) {{\n{2}    }}\n"
-      "    iter() {{ this }}\n"
-      "    has_next() {{\n"
-      "      if this._g_drained {{ return false }}\n"
-      "      if this._g_has_la {{ return true }}\n"
-      "      if this._g_inited {{\n"
-      "{3}\n"
-      "      }} else {{\n"
-      "{4}\n"
-      "        this._g_inited = true\n"
-      "      }}\n"
-      "      while {5} {{\n"
-      "{6}\n"
-      "        {7}\n"
-      "{8}\n"
-      "      }}\n"
-      "      this._g_drained = true\n"
-      "      return false\n"
-      "    }}\n"
-      "    next() {{\n"
-      "      if !this._g_has_la {{ this.has_next() }}\n"
-      "      let _v = this._g_la\n"
-      "      this._g_la = nil\n"
-      "      this._g_has_la = false\n"
-      "      return _v\n"
-      "    }}\n"
-      "    dispose() {{\n"
-      "      if this._g_disposed {{ return nil }}\n"
-      "      this._g_disposed = true\n"
-      "      this._g_drained = true\n"
-      "      if this._g_inited {{\n"
-      "{10}"
-      "      }}\n"
-      "    }}\n"
-      "  }}\n"
-      "  {0}.new({9})\n"
-      "}}\n",
-      gen_name, ctor_params, ctor_inits,
-      post_yield_src, pre_loop_src,
-      cond_src, pre_yield_src, yield_stmt_src, post_yield_src,
-      ctor_call_args, dispose_body_src));
-  swap_body_from_wrapper(ast, synthesized);
-  return ast;
-}
-
-// --- Stage 6b: yield from via phase machine ------------------------------
-
-// WHILE body acceptable by Stage 6b: zero or more leading statements
-// (typically `let x = _g_it.next()` after Stage 5 desugar) followed by
-// a single YIELD or YIELD_FROM as the final stmt. Bodies with multiple
-// yields, branches, or yield-from nested deeper than top level are
-// rejected — Stage 6b falls back to the dispatcher's error path so the
-// user gets a clean SyntaxError instead of silent miscompilation.
-struct While6bBody {
-  std::vector<const peg::Ast*> pre_stmts;
-  const peg::Ast* yield_node;  // YIELD or YIELD_FROM
-  bool is_yield_from;
 };
 
-inline std::optional<While6bBody> analyze_while_body_for_stage6b(
-    const peg::Ast& while_node) {
-  using namespace peg::udl;
-  if (while_node.nodes.size() < 2) return std::nullopt;
-  const auto& body = *while_node.nodes[1];
-  auto stmts = body_stmts(body);
-  While6bBody result;
-  for (size_t i = 0; i < stmts.size(); i++) {
-    auto* u = unwrap_stmt(stmts[i]);
-    if (u->tag == "YIELD"_ || u->tag == "YIELD_FROM"_) {
-      if (i + 1 != stmts.size()) return std::nullopt;
-      result.yield_node = u;
-      result.is_yield_from = (u->tag == "YIELD_FROM"_);
-      return result;
-    }
-    // Reject nested yields inside non-terminal stmts.
-    if (fn_body_has_yield(*stmts[i])) return std::nullopt;
-    result.pre_stmts.push_back(stmts[i]);
-  }
-  return std::nullopt;
-}
-
-// Emit the body of a single phase block of has_next(), with locals
-// rewritten via `rewrite_locals_to_this`. Each phase ends with either
-// `return true` (yielded a value), `continue` (state advanced, restart
-// the dispatch loop), or `return false` (drained).
-inline std::string emit_stage6b_phase_block(
-    int next_phase, const peg::Ast& stmt,
-    const char* src, size_t src_len,
-    const std::set<std::string>& rewrite_set) {
-  using namespace peg::udl;
-  auto* u = unwrap_stmt(&stmt);
-  if (u->tag == "YIELD"_ && !u->nodes.empty()) {
-    auto expr = rewrite_locals_to_this(
-        ast_source_slice(*u->nodes[0], src, src_len), rewrite_set);
-    return std::format(
-        "        this._g_la = ({0})\n"
-        "        this._g_has_la = true\n"
-        "        this._g_phase = {1}\n"
-        "        return true\n",
-        expr, next_phase);
-  }
-  if (u->tag == "YIELD_FROM"_ && !u->nodes.empty()) {
-    auto expr = rewrite_locals_to_this(
-        ast_source_slice(*u->nodes[0], src, src_len), rewrite_set);
-    return std::format(
-        "        this._g_delegate = ({0}).iter()\n"
-        "        this._g_phase = {1}\n"
-        "        continue\n",
-        expr, next_phase);
-  }
-  if (u->tag == "WHILE"_) {
-    auto wb = analyze_while_body_for_stage6b(*u);
-    if (!wb) return {};
-    auto cond = rewrite_locals_to_this(
-        ast_source_slice(*u->nodes[0], src, src_len), rewrite_set);
-    std::string pre;
-    for (auto* s : wb->pre_stmts) {
-      pre += "          ";
-      pre += rewrite_locals_to_this(
-          ast_source_slice(*s, src, src_len), rewrite_set);
-      pre += "\n";
-    }
-    auto yexpr = rewrite_locals_to_this(
-        ast_source_slice(*wb->yield_node->nodes[0], src, src_len), rewrite_set);
-    std::string yield_part;
-    if (wb->is_yield_from) {
-      yield_part = std::format(
-          "          this._g_delegate = ({0}).iter()\n"
-          "          continue\n",
-          yexpr);
-    } else {
-      yield_part = std::format(
-          "          this._g_la = ({0})\n"
-          "          this._g_has_la = true\n"
-          "          return true\n",
-          yexpr);
-    }
-    return std::format(
-        "        if {0} {{\n"
-        "{1}"
-        "{2}"
-        "        }} else {{\n"
-        "          this._g_phase = {3}\n"
-        "          continue\n"
-        "        }}\n",
-        cond, pre, yield_part, next_phase);
-  }
-  // Plain statement: execute verbatim (with locals rewritten) and advance.
-  auto stmt_rw = rewrite_locals_to_this(
-      ast_source_slice(stmt, src, src_len), rewrite_set);
-  return std::format(
-      "        {0}\n"
-      "        this._g_phase = {1}\n"
-      "        continue\n",
-      stmt_rw, next_phase);
-}
-
-inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage6b(
+// CPS transform entry. Returns the transformed ast on success, or the
+// original ast unchanged when the body uses a construct outside the
+// engine's scope (caller then reports / falls back).
+inline std::shared_ptr<peg::Ast> transform_one_generator_fn_cps(
     std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len,
-    const peg::Ast& name_ast,
-    const peg::Ast& params_ast) {
+    const peg::Ast& name_ast, const peg::Ast& params_ast) {
   using namespace peg::udl;
+
   auto gen_name = std::format("_Gen_{}_{}_{}",
                               std::string(name_ast.token),
                               name_ast.line, name_ast.column);
@@ -862,39 +600,43 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage6b(
   std::set<std::string> rewrite_set = locals;
   for (auto& pn : param_names) rewrite_set.insert(std::string(pn));
 
+  CpsBuilder b{src, src_len, rewrite_set, {}};
+  b.terminal = b.fresh();
+  b.states[b.terminal] =
+      "      this._g_drained = true\n      return false\n";
+  int entry = b.compile_seq(body_stmts(*ast->nodes.back()), b.terminal);
+  if (b.failed || entry < 0) return ast;  // unsupported shape
+
   std::string ctor_params;
   std::string ctor_call_args;
-  std::string ctor_inits =
+  std::string ctor_inits = std::format(
       "      this._g_drained = false\n"
       "      this._g_has_la = false\n"
       "      this._g_la = nil\n"
       "      this._g_disposed = false\n"
       "      this._g_delegate = nil\n"
-      "      this._g_phase = 0\n";
+      "      this._g_state = {}\n",
+      entry);
+  for (size_t k = 0; k < b.defer_bodies.size(); k++) {
+    ctor_inits += std::format("      this._g_defer_{} = false\n", k);
+  }
   emit_ctor_param_and_local_inits(param_names, locals,
                                   ctor_params, ctor_call_args, ctor_inits);
 
-  // Walk top-level body statements and build phase blocks. Last phase
-  // is the synthetic "drained" terminator so each real phase can hand
-  // off to its successor with a simple ++index.
-  auto top_stmts = body_stmts(*ast->nodes.back());
-  std::string phases_src;
-  int phase_idx = 0;
-  for (auto* stmt : top_stmts) {
-    auto block = emit_stage6b_phase_block(phase_idx + 1,
-                                          *stmt, src, src_len, rewrite_set);
-    if (block.empty()) return ast;  // unsupported shape — caller will report
-    phases_src += std::format("      if this._g_phase == {} {{\n{}      }}\n",
-                              phase_idx, block);
-    phase_idx++;
+  std::string dispatch;
+  for (size_t id = 0; id < b.states.size(); id++) {
+    dispatch += std::format(
+        "      if this._g_state == {} {{\n{}      }}\n", id, b.states[id]);
   }
-  // Terminator phase.
-  phases_src += std::format(
-      "      if this._g_phase == {} {{\n"
-      "        this._g_drained = true\n"
-      "        return false\n"
-      "      }}\n",
-      phase_idx);
+
+  // Registered defers run LIFO at dispose, each gated on its reach flag.
+  // `defer_bodies` is already in reverse source order (compile_seq walks
+  // statements back-to-front), so iterating it forward IS the LIFO order.
+  std::string defer_runs;
+  for (size_t k = 0; k < b.defer_bodies.size(); k++) {
+    defer_runs += std::format(
+        "      if this._g_defer_{} {{ {} }}\n", k, b.defer_bodies[k]);
+  }
 
   auto synthesized = std::make_shared<std::string>(std::format(
       "fn __gen_wrapper__() {{\n"
@@ -932,39 +674,38 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn_stage6b(
       "        if this._g_delegate.has('dispose') {{ this._g_delegate.dispose() }}\n"
       "        this._g_delegate = nil\n"
       "      }}\n"
+      "{5}"
       "    }}\n"
       "  }}\n"
       "  {0}.new({4})\n"
       "}}\n",
-      gen_name, ctor_params, ctor_inits, phases_src, ctor_call_args));
+      gen_name, ctor_params, ctor_inits, dispatch, ctor_call_args,
+      defer_runs));
   swap_body_from_wrapper(ast, synthesized);
   return ast;
 }
 
-// Dispatcher: pattern-match the body and route to the right stage.
-// Stage 5 runs first as a source-level pre-pass that rewrites yielding
-// `for-in` loops into `while + iterator` form, then Stage 3 handles the
-// result. Stage 6b takes any body containing `yield from` and emits a
-// phase machine instead. Stage 3 (verbatim while-preserve) is the
-// primary backend for plain yield generators; Stage 1's eager-eval path
-// catches straight-line bodies whose yield expressions don't reference
-// loop-mutated locals.
+// Dispatcher: lower a yield-carrying fn to the flat-dispatch CPS state
+// machine. Two source-level pre-passes run first: the C# rule rejects
+// yield inside try-catch/defer, and the for-in desugar rewrites every
+// yielding `for x in e` to `while it.has_next()` form (to a fixpoint so
+// nested for-ins are covered) since the CPS engine works over while.
+// Everything else — straight-line yields, while/if branching, multiple
+// yields per iteration, post-loop tails, break/continue/return, defer,
+// yield from — is handled by the one engine.
 inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
     std::shared_ptr<peg::Ast> ast, const char* src, size_t src_len) {
   using namespace peg::udl;
   size_t i = 0;
   while (i < ast->nodes.size() && ast->nodes[i]->tag == "DECORATOR"_) i++;
   if (i + 2 >= ast->nodes.size()) return ast;
-  auto yields = collect_yields(*ast->nodes.back());
-  bool has_yf = body_has_yield_from(*ast->nodes.back());
-  if (yields.empty() && !has_yf) return ast;
+  if (!fn_body_has_yield(*ast->nodes.back())) return ast;
 
   // C# rule (CS1626): a yield statement may not appear inside a try-catch
-  // or defer block. The state-machine cost of supporting yield-spanning
-  // try blocks is permanently out of scope for culebra ([[generator-design]]
-  // §仕様凍結項目). Cleanup belongs in `defer { ... }` at body top level;
-  // value-level error recovery belongs in the yielded expression
-  // (`yield try { ... } catch e { ... }`).
+  // or defer block. yield-spanning try is permanently out of scope
+  // ([[project-generator-design]] §仕様凍結項目). Cleanup belongs in a
+  // top-level `defer { ... }`; value-level recovery in the yielded
+  // expression (`yield try { ... } catch e { ... }`).
   if (auto* bad = find_yield_inside_try_or_defer(*ast->nodes.back())) {
     throw CulebraError(
         "SyntaxError",
@@ -975,10 +716,12 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
         static_cast<long>(bad->column));
   }
 
-  // Stage 5: rewrite yielding for-in loops to while + iterator at source
-  // level, then re-parse so Stage 3 picks them up.
-  if (auto rewritten = rewrite_yielding_fors_to_while(
-          *ast->nodes.back(), src, src_len)) {
+  // Desugar yielding for-in loops to while + iterator, re-parsing each
+  // time, until none remain (nested for-ins surface as outermost on the
+  // next pass). After the swap, params/body positions point into the
+  // synthesized source, so `src`/`src_len` track it.
+  while (auto rewritten = rewrite_yielding_fors_to_while(
+             *ast->nodes.back(), src, src_len)) {
     auto params_sv = ast_source_slice(*ast->nodes[i + 1], src, src_len);
     auto body_inner = strip_block_braces(*rewritten);
     auto desugared = std::make_shared<std::string>(std::format(
@@ -987,76 +730,25 @@ inline std::shared_ptr<peg::Ast> transform_one_generator_fn(
     if (!swap_body_with_wrapper_params(ast, desugared, i)) return ast;
     src = desugared->data();
     src_len = desugared->size();
-    yields = collect_yields(*ast->nodes.back());
-    has_yf = body_has_yield_from(*ast->nodes.back());
-    if (yields.empty() && !has_yf) return ast;
+    if (!fn_body_has_yield(*ast->nodes.back())) return ast;
   }
 
-  // Stage 6a defer scope: only top-level `defer { ... }` in the body is
-  // supported (lifted into the generator's defer registry at dispose
-  // time). Defers buried in loop / if / match bodies have no clean
-  // translation today — surface as a SyntaxError instead of silently
-  // letting the existing scope-local defer mechanism mis-fire on yield.
-  auto all_defers = collect_defers(*ast->nodes.back());
   const auto& name_ast = *ast->nodes[i];
   const auto& params_ast = *ast->nodes[i + 1];
+  auto orig_body = ast->nodes.back();
+  auto out = transform_one_generator_fn_cps(ast, src, src_len, name_ast,
+                                            params_ast);
+  if (out->nodes.back().get() != orig_body.get()) return out;
 
-  // Stage 6b: any body containing `yield from` goes through the phase
-  // machine codegen instead of Stage 3's verbatim while-preserve. The
-  // transformer leaves the body untouched when it can't pattern-match
-  // the shape; surface that as a SyntaxError so the user gets a clear
-  // failure mode rather than silent fallthrough to Stage 1.
-  if (has_yf) {
-    auto orig_body = ast->nodes.back();
-    auto out = transform_one_generator_fn_stage6b(ast, src, src_len,
-                                                   name_ast, params_ast);
-    if (out->nodes.back().get() == orig_body.get()) {
-      throw CulebraError(
-          "SyntaxError",
-          "yield from is only supported in the Stage 6b minimum scope: "
-          "linear sequence of yield / yield from at body top level, "
-          "optionally with a single trailing for-in / while whose body "
-          "is a single yield or yield from. Nested / branching "
-          "delegation is not yet supported.",
-          static_cast<long>(name_ast.line),
-          static_cast<long>(name_ast.column));
-    }
-    return out;
-  }
-
-  if (auto p = match_stage3_pattern(*ast->nodes.back(), yields)) {
-    if (!all_defers.empty()) {
-      std::set<const peg::Ast*> pre_loop_defers;
-      for (auto* stmt : p->pre_loop) {
-        auto* unwrapped = unwrap_stmt(stmt);
-        if (unwrapped->tag == "DEFER"_) pre_loop_defers.insert(unwrapped);
-      }
-      for (auto* d : all_defers) {
-        if (!pre_loop_defers.contains(d)) {
-          throw CulebraError(
-              "SyntaxError",
-              "defer in generator must be at the body's top level "
-              "(before the loop). Defers nested inside loop / if / match "
-              "bodies are not supported.",
-              static_cast<long>(d->line),
-              static_cast<long>(d->column));
-        }
-      }
-    }
-    return transform_one_generator_fn_stage3(ast, src, src_len, name_ast,
-                                             params_ast, *p, yields);
-  }
-  if (!all_defers.empty()) {
-    auto* d = all_defers.front();
-    throw CulebraError(
-        "SyntaxError",
-        "defer in generator requires a loop body (while or for-in). "
-        "Straight-line generators have no drain point to attach the "
-        "cleanup to.",
-        static_cast<long>(d->line),
-        static_cast<long>(d->column));
-  }
-  return transform_one_generator_fn_stage1(ast, src, src_len, name_ast, yields);
+  // CPS left the body untouched — it hit a construct it can't lower
+  // (e.g. a yielding `match` arm, which the grammar already forbids, or a
+  // break/continue outside any loop).
+  throw CulebraError(
+      "SyntaxError",
+      "unsupported control flow in a generator body (yield reachable "
+      "through a construct the generator transform can't lower).",
+      static_cast<long>(name_ast.line),
+      static_cast<long>(name_ast.column));
 }
 
 // Walk the AST, transforming every yield-carrying MULTIFN_DECL. The

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -4593,6 +4593,36 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
     return Value();
   }
 
+  // Lower a single type annotation slot in place to its runtime-check
+  // form (see shared.h::lower_type_params). Rewritten strings are owned
+  // by generic_type_storage_ so their string_views outlive the call.
+  void neutralize_type_slot(
+      std::string_view& slot,
+      const std::vector<std::string_view>& type_params) {
+    if (type_params.empty() || slot.empty()) return;
+    auto rewritten = culebra::lower_type_params(slot, type_params);
+    if (rewritten == slot) return;
+    if (rewritten == "Any") { slot = "Any"; return; }
+    auto storage = std::make_shared<std::string>(std::move(rewritten));
+    generic_type_storage_.push_back(storage);
+    slot = *storage;
+  }
+
+  // Lower all param + return annotations on a function signature,
+  // snapshotting the original annotation into declared_type_name first
+  // so introspection still surfaces `T` / `Array<T>`. Shared by class
+  // methods and free (multifn) functions carrying Generic type-params.
+  void neutralize_fn_type_params(
+      FunctionValue& fn,
+      const std::vector<std::string_view>& type_params) {
+    if (type_params.empty()) return;
+    for (auto& p : *fn.params) {
+      p.declared_type_name = p.type_name;
+      neutralize_type_slot(p.type_name, type_params);
+    }
+    neutralize_type_slot(fn.return_type, type_params);
+  }
+
   Value eval_multifn_decl(const peg::Ast& ast,
                           std::shared_ptr<Environment> env) {
     using namespace peg::udl;
@@ -4609,9 +4639,14 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
     }
 
     // CLASS_HEAD may carry Generic params (`min<T: Comparable>`); the
-    // bound name is the outer only. Mirrors eval_class_decl.
-    auto name_view = parse_generic_head(ast.nodes[i]->token).outer;
+    // bound name is the outer only. Mirrors eval_class_decl. The
+    // type-params themselves drive neutralization below so a bare `T`
+    // param lowers to "Any" (unbounded) or its bound trait (bounded).
+    auto mf_head = parse_generic_head(ast.nodes[i]->token);
+    auto name_view = mf_head.outer;
     auto name_owned = std::string(name_view);
+    std::vector<std::string_view> type_params;
+    if (!mf_head.args.empty()) type_params = split_generic_args(mf_head.args);
 
     // Children: CLASS_HEAD, PARAMETERS, [RETURN_TYPE,] BLOCK
     size_t params_idx = i + 1;
@@ -4626,6 +4661,7 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
                                        ast.nodes[body_idx],
                                        return_type, env);
     fn_val.get<FunctionValue>().name = std::string(name_view);
+    neutralize_fn_type_params(fn_val.get<FunctionValue>(), type_params);
 
     if (!decorators.empty()) {
       // Apply decorators bottom-up: the closest to the `fn` keyword
@@ -4776,30 +4812,6 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
       reject_class_decl_in_class_body(mv.is_field ? *mv.value : **mv.body,
                                        class_name);
     }
-    // Rewrite ANY occurrence of a type-param (`T`, `Array<T>`, `T | Long`)
-    // to "Any" — runtime check sees Any, introspection sees the rewritten
-    // canonical form. Owned storage lives in generic_type_storage_ so
-    // string_views remain valid for the Interpreter's lifetime.
-    auto neutralize_one = [&](std::string_view& slot) {
-      if (type_params.empty() || slot.empty()) return;
-      auto rewritten = culebra::rewrite_type_params_to_any(slot, type_params);
-      if (rewritten == slot) return;
-      if (rewritten == "Any") { slot = "Any"; return; }
-      auto storage = std::make_shared<std::string>(std::move(rewritten));
-      generic_type_storage_.push_back(storage);
-      slot = *storage;
-    };
-    auto neutralize_type_params = [&](FunctionValue& fn) {
-      // Snapshot original declared annotation BEFORE rewriting type_name,
-      // so introspection can recover `T` / `Array<T>` even though runtime
-      // checks see the rewritten form.
-      for (auto& p : *fn.params) {
-        p.declared_type_name = p.type_name;
-        neutralize_one(p.type_name);
-      }
-      neutralize_one(fn.return_type);
-    };
-
     const peg::Ast* new_ast = nullptr;
     std::vector<std::pair<std::string_view, Value>> method_template;
     std::vector<std::pair<std::string_view, Value>> static_template;
@@ -4819,7 +4831,7 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
       }
       auto fn_val = make_function_value(*mv.params, *mv.body, {}, env);
       fn_val.get<FunctionValue>().name = std::string(mv.name);
-      neutralize_type_params(fn_val.get<FunctionValue>());
+      neutralize_fn_type_params(fn_val.get<FunctionValue>(), type_params);
       if (mv.is_static) {
         static_template.push_back({mv.name, std::move(fn_val)});
       } else {
@@ -4858,7 +4870,7 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
       // with method params.
       for (auto& p : ctor_params) {
         p.declared_type_name = p.type_name;
-        neutralize_one(p.type_name);
+        neutralize_type_slot(p.type_name, type_params);
       }
       auto body = *ctor_view.body;
       auto self = shared_from_this();

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -4149,11 +4149,22 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
       throw iter_proto_error("iterator missing has_next()/next()");
     }
 
+    // Iterator dispose protocol: call iter.dispose() on every exit path
+    // (drain / break / exception). Default trait impl is a no-op, so
+    // built-in iterators pay just a method lookup; generators override
+    // to run registered defers. See [[generator-design]] §dispose.
+    auto dispose_iter = [&]() {
+      if (iter_val.type != Value::Object) return;
+      const auto& iter_obj = iter_val.to_object();
+      if (!iter_obj.has("dispose")) return;
+      _invoke_method_no_args(iter_val, "dispose");
+    };
+
     // Drive via the Kotlin-style protocol: `has_next()` gates each
     // `next()`. `_iter_next_value` already encapsulates that pair.
     for (;;) {
       auto v = _iter_next_value(iter_val);
-      if (!v) break;
+      if (!v) { dispose_iter(); break; }
 
       auto scopeEnv = make_scope(env);
       scopeEnv->initialize(var_name, std::move(*v), false);
@@ -4162,12 +4173,14 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
         run_deferred(scopeEnv);
       } catch (const BreakSignal&) {
         run_deferred(scopeEnv);
+        dispose_iter();
         return Value();
       } catch (const ContinueSignal&) {
         run_deferred(scopeEnv);
-        // fall through
+        // fall through (loop continues; dispose only at final exit)
       } catch (...) {
         run_deferred(scopeEnv);
+        try { dispose_iter(); } catch (...) {}  // preserve in-flight throw
         throw;
       }
     }

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -4970,12 +4970,15 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
     using namespace peg::udl;
     size_t k = 0;
     while (k < ast.nodes.size() && ast.nodes[k]->tag == "DECORATOR"_) k++;
-    // CLASS_HEAD may carry Generic params; outer is the trait name.
-    auto head = parse_generic_head(ast.nodes[k]->token);
-    auto trait_name = std::string(head.outer);
+    // TRAIT_HEAD: trait name (+ optional Generic params) and optional
+    // supertrait list (`trait Ord: Eq`). Supertrait methods are flattened
+    // into this trait by register_trait.
+    auto th = culebra::parse_trait_head(ast.nodes[k]->token);
+    auto trait_name = std::string(parse_generic_head(th.name).outer);
 
     TraitDef def;
     def.name = trait_name;
+    for (auto super : th.supertraits) def.supertraits.emplace_back(super);
 
     // Per-method default body storage (interp-side). Owned by the trait
     // — every conforming instance shares one FunctionValue per default.

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -139,6 +139,17 @@ inline int multifn_specificity(std::string_view param_type,
     // bare concrete param outranks it. Lower-tier alts pass through.
     return best >= 6 ? 4 : best;
   }
+  // Composite bound (`A + B`): all-of. The arg must satisfy every
+  // part; score is the best part's tier (parts are traits → 3).
+  if (has_toplevel_plus(param_type)) {
+    int best = -1;
+    for (auto part : split_intersection_types(param_type)) {
+      int s = multifn_specificity(part, arg_type);
+      if (s < 0) return -1;
+      if (s > best) best = s;
+    }
+    return best;
+  }
   // Generic: outer-match against arg label (arg side carries no
   // type args today, so the args part only tie-breaks against bare
   // outer-only annotations).
@@ -1824,6 +1835,13 @@ inline bool type_matches(const Value& val, std::string_view name) {
       if (type_matches(val, candidate)) return true;
     }
     return false;
+  }
+  // Composite bound (`A + B`) — all-of: conform to every part.
+  if (has_toplevel_plus(name)) {
+    for (auto part : split_intersection_types(name)) {
+      if (!type_matches(val, part)) return false;
+    }
+    return true;
   }
   // Generic outer-match: `Array<Long>` checks `Array` only (element
   // type is documentation in the MVP, see [[project_type_system]]).

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -722,6 +722,13 @@ struct ObjectValue {
   explicit ObjectValue(Synthetic) {}
 
   bool has(std::string_view name) const;
+  // Own-field existence, excluding builtin methods. `has()` returns true
+  // for builtin method names (`size`/`keys`/...) even when the instance
+  // carries no such field, which is what property *reads* want (the
+  // builtin is the fallback). Assignment-target checks must use this
+  // instead, or `this.size = v` on a fresh field routes to `assign()`
+  // (which expects an existing slot) instead of `initialize()`.
+  bool has_own(std::string_view name) const;
   const Value& get(std::string_view name) const;
   void assign(std::string_view name, const Value& val);
   void initialize(std::string_view name, const Value& val, bool mut);
@@ -1677,6 +1684,10 @@ inline bool ObjectValue::has(std::string_view name) const {
     return props.contains(name);
   }
   return true;
+}
+
+inline bool ObjectValue::has_own(std::string_view name) const {
+  return properties->contains(name);
 }
 
 inline const Value& ObjectValue::get(std::string_view name) const {
@@ -5989,10 +6000,12 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
           auto& obj = lval.to_object();
           auto name = postfix.token;
           if (compound) {
-            if (!obj.has(name)) {
+            if (!obj.has_own(name)) {
               // Shared helper so the JIT path (see jit.h
               // `compile_assignment` DOT-compound branch) raises
               // the same AttributeError with location attached.
+              // has_own (not has) so a builtin-named miss still errors
+              // rather than compounding against a builtin method value.
               throw_compound_missing_property_at(
                   static_cast<long>(postfix.line),
                   static_cast<long>(postfix.column));
@@ -6005,7 +6018,10 @@ struct Interpreter : std::enable_shared_from_this<Interpreter> {
             obj.assign(name, new_val);
             return new_val;
           }
-          if (obj.has(name)) {
+          // has_own: a fresh field whose name shadows a builtin method
+          // (`size`/`keys`/...) must initialize a new slot, not route to
+          // assign() which expects an existing property.
+          if (obj.has_own(name)) {
             obj.assign(name, rval);
           } else {
             obj.initialize(name, rval, mut);

--- a/include/jit.h
+++ b/include/jit.h
@@ -8596,6 +8596,14 @@ struct JIT {
       for (auto& c : node.nodes) any |= scan_eh_defer(*c, at_fn_top, info);
       return any;
     }
+    if (node.tag == "FOR"_) {
+      // for-in over the iterator protocol (Object iter() path) emits an
+      // exception landingpad in compile_for_protocol_loop so iter.dispose()
+      // fires even when the body throws. The landingpad requires the
+      // enclosing function to carry a personality, so flag it here even
+      // though no try/defer is present.
+      info.has_eh = true;
+    }
     if (node.tag == "LEXICAL_SCOPE"_) {
       bool inner = false;
       for (auto& c : node.nodes) inner |= scan_eh_defer(*c, false, info);
@@ -11364,6 +11372,37 @@ struct JIT {
     auto condBB = llvm::BasicBlock::Create(ctx_, "for.p.cond", fn);
     auto bodyBB = llvm::BasicBlock::Create(ctx_, "for.p.body", fn);
     auto cleanupBB = llvm::BasicBlock::Create(ctx_, "for.p.cleanup", fn);
+    auto excLpadBB = llvm::BasicBlock::Create(ctx_, "for.p.exc", fn);
+    auto disposeKeyPtr = get_or_create_global_str("dispose", ".dispose.key");
+
+    // Iterator trait dispose: call iter.dispose() if the class carries
+    // one (default trait impl is no-op, so trait-only coverage skips the
+    // call), then release the iterator slot contents. Shared between the
+    // natural-exit/break path (cleanupBB) and the exception landingpad
+    // (excLpadBB) — both run the same cleanup before continuing.
+    auto emit_iter_dispose_and_release = [&](const char* label_prefix) {
+      auto iterFinal = builder_.CreateLoad(valueType_, iterAlloca,
+                                           (std::string(label_prefix) + ".iter").c_str());
+      auto iterFinalPtr = builder_.CreateIntToPtr(
+          extract_data(iterFinal), ptrTy,
+          (std::string(label_prefix) + ".iter.ptr").c_str());
+      auto hasDispose = emit_object_has(
+          iterFinalPtr, disposeKeyPtr,
+          (std::string(label_prefix) + ".has_dispose").c_str());
+      auto disposeBB = llvm::BasicBlock::Create(
+          ctx_, (std::string(label_prefix) + ".dispose").c_str(), fn);
+      auto skipBB = llvm::BasicBlock::Create(
+          ctx_, (std::string(label_prefix) + ".skip").c_str(), fn);
+      builder_.CreateCondBr(hasDispose, disposeBB, skipBB);
+
+      builder_.SetInsertPoint(disposeBB);
+      auto dispose_fn_val = compile_property_get(iterFinal, "dispose");
+      compile_function_call_raw(dispose_fn_val, iterFinal, {});
+      builder_.CreateBr(skipBB);
+
+      builder_.SetInsertPoint(skipBB);
+      emit_value_release(iterFinal);
+    };
 
     builder_.CreateBr(condBB);
 
@@ -11388,14 +11427,34 @@ struct JIT {
     llvm::Value* loop_val = llvm::UndefValue::get(valueType_);
     loop_val = builder_.CreateInsertValue(loop_val, outTag, {0});
     loop_val = builder_.CreateInsertValue(loop_val, outData, {1});
+    // Route in-body exceptions through excLpadBB so iter dispose + release
+    // fire before unwinding continues. Restore the prior landingpad after
+    // the body finishes so the cleanupBB / break paths still inherit the
+    // outer one for any post-cleanup exceptions.
+    auto savedLpad = current_lpad_;
+    current_lpad_ = excLpadBB;
     emit_for_body_with_owned_binding(var_name, loop_val, body, condBB,
                                      cleanupBB);
+    current_lpad_ = savedLpad;
 
-    // cleanupBB: release the iterator slot contents, exit the for-in
+    // cleanupBB: natural-exit and break path.
     builder_.SetInsertPoint(cleanupBB);
-    auto iterFinal = builder_.CreateLoad(valueType_, iterAlloca, "iter.fin");
-    emit_value_release(iterFinal);
+    emit_iter_dispose_and_release("for.p");
     builder_.CreateBr(endBB);
+
+    // excLpadBB: exception path. Catches, runs the same dispose + release,
+    // then rethrows so the exception keeps unwinding to whatever outer
+    // landingpad (or function exit) is active.
+    builder_.SetInsertPoint(excLpadBB);
+    auto lpadTy = llvm::StructType::get(ptrTy, builder_.getInt32Ty());
+    auto lpad = builder_.CreateLandingPad(lpadTy, 1, "for.p.lpad");
+    lpad->addClause(llvm::ConstantPointerNull::get(ptrTy));
+    auto excPtr = builder_.CreateExtractValue(lpad, {0});
+    builder_.CreateCall(
+        module_->getOrInsertFunction("__cxa_begin_catch", ptrTy, ptrTy),
+        {excPtr});
+    emit_iter_dispose_and_release("for.p.exc");
+    emit_rethrow(savedLpad);
   }
 
   void compile_for_string_loop(llvm::Value* strPtr,

--- a/include/jit.h
+++ b/include/jit.h
@@ -3453,6 +3453,22 @@ culebra_runtime_register_trait_method(const char* trait_name,
   culebra::trait_conformance_cache().clear();
 }
 
+// Flatten a supertrait's methods into `trait_name` at runtime (trait
+// inheritance). Emitted by compile_trait_decl after the trait's own
+// methods so the AOT-binary registry mirrors the interp register_trait
+// flatten. The supertrait is declared earlier, so it is already
+// registered when this runs.
+CULEBRA_RT_KEEP CULEBRA_RT_INLINE void
+culebra_runtime_register_trait_super(const char* trait_name,
+                                      const char* super_name) {
+  std::unique_lock lock(culebra::trait_mutex());
+  auto& reg = culebra::trait_registry();
+  auto& def = reg[trait_name];
+  if (def.name.empty()) def.name = trait_name;
+  culebra::merge_supertrait_into(def, super_name);
+  culebra::trait_conformance_cache().clear();
+}
+
 // Side table mapping a dispatcher closure pointer to its multimethod
 // name, so the shared static thunk can recover which name to dispatch
 // for. Dispatchers live for the lifetime of the program (held by the
@@ -6213,6 +6229,8 @@ inline constexpr auto register_trait_default
     = "culebra_runtime_register_trait_default";
 inline constexpr auto register_trait_method
     = "culebra_runtime_register_trait_method";
+inline constexpr auto register_trait_super
+    = "culebra_runtime_register_trait_super";
 inline constexpr auto type_error          = "culebra_runtime_type_error";
 inline constexpr auto destructure_mismatch
     = "culebra_runtime_destructure_mismatch";
@@ -11668,11 +11686,13 @@ struct JIT {
     using namespace peg::udl;
     size_t k = 0;
     while (k < ast.nodes.size() && ast.nodes[k]->tag == "DECORATOR"_) k++;
-    auto head = culebra::parse_generic_head(ast.nodes[k]->token);
-    std::string trait_name(head.outer);
+    // TRAIT_HEAD: name (+ Generic params) and optional supertraits.
+    auto th = culebra::parse_trait_head(ast.nodes[k]->token);
+    std::string trait_name(culebra::parse_generic_head(th.name).outer);
 
     culebra::TraitDef def;
     def.name = trait_name;
+    for (auto super : th.supertraits) def.supertraits.emplace_back(super);
     auto& defaults = _jit_trait_default_impls()[trait_name];
     defaults.clear();
 
@@ -11733,6 +11753,24 @@ struct JIT {
                 rt::register_trait_default,
                 builder_.getVoidTy(), ptrTy, ptrTy, ptrTy),
             {trait_g, method_g, closure_ptr});
+      }
+    }
+    // Emit supertrait-merge calls so the AOT-binary runtime flattens
+    // inherited methods (mirrors interp's register_trait). The JIT-phase
+    // register_trait(def) below flattens in-process for the same effect.
+    {
+      auto ptrTy = llvm::PointerType::get(ctx_, 0);
+      for (auto super : th.supertraits) {
+        auto trait_g = builder_.CreateGlobalString(
+            trait_name, ".trait." + trait_name + ".sup.tn");
+        auto super_g = builder_.CreateGlobalString(
+            std::string(super),
+            ".trait." + trait_name + ".sup." + std::string(super));
+        emit_call(
+            module_->getOrInsertFunction(
+                rt::register_trait_super,
+                builder_.getVoidTy(), ptrTy, ptrTy),
+            {trait_g, super_g});
       }
     }
     culebra::register_trait(std::move(def));

--- a/include/jit.h
+++ b/include/jit.h
@@ -1687,6 +1687,14 @@ inline const char* _culebra_tag_name(int8_t tag) {
 inline bool _culebra_type_matches_single(int8_t tag, int64_t data,
                                           std::string_view expected) {
   if (expected == "Any") return true;
+  // Composite bound (`A + B`) — all-of: conform to every part.
+  // Mirrors interp's type_matches.
+  if (culebra::has_toplevel_plus(expected)) {
+    for (auto part : culebra::split_intersection_types(expected)) {
+      if (!_culebra_type_matches_single(tag, data, part)) return false;
+    }
+    return true;
+  }
   // Generic outer-match: `Array<Long>` checks `Array` only. Element
   // type is documentation in the MVP (matches interp's type_matches).
   if (expected.find('<') != std::string_view::npos) {

--- a/include/jit.h
+++ b/include/jit.h
@@ -7468,10 +7468,12 @@ struct JIT {
   std::map<const peg::Ast*, FuncInfo> func_info_;
   FuncInfo main_info_;
 
-  // When compiling methods of `class Foo<T, U>`, holds {"T", "U"} so
-  // param annotations naming a type-param can be rewritten to "Any"
-  // (Phase 2 MVP: type-params are documentation, runtime sees Any).
-  // Cleared back to empty after the class is done compiling.
+  // Holds the active function's Generic type-params ({"T", "U"}) while
+  // its param annotations are compiled, so each can be lowered
+  // (unbounded -> "Any", bounded -> bound trait; see lower_type_params).
+  // Set for class methods (`class Foo<T, U>`) and free multifns
+  // (compile_multifn_decl); compile_fn_common clears it before
+  // descending so nested fns don't inherit it.
   std::vector<std::string_view> class_type_params_;
 
   // Absolute on-disk path of the module currently being compiled.
@@ -12090,9 +12092,15 @@ struct JIT {
     bool has_decorators = dec_end > 0;
 
     // CLASS_HEAD may carry Generic params (`sort<T: Comparable>`); the
-    // bound name is the outer only. Mirrors compile_class_decl.
-    std::string name(culebra::parse_generic_head(
-        ast.nodes[dec_end]->token).outer);
+    // bound name is the outer only. Mirrors compile_class_decl. The
+    // type-params drive lowering of bare `T` params both in the body's
+    // emit_type_check (via class_type_params_, set below) and in the
+    // dispatch param-type strings registered with the multimethod.
+    auto mf_head = culebra::parse_generic_head(ast.nodes[dec_end]->token);
+    std::string name(mf_head.outer);
+    std::vector<std::string_view> mf_type_params;
+    if (!mf_head.args.empty())
+      mf_type_params = culebra::split_generic_args(mf_head.args);
     const peg::Ast* params_ast = ast.nodes[dec_end + 1].get();
     size_t body_idx = dec_end + 2;
     std::string_view returnType;
@@ -12106,6 +12114,10 @@ struct JIT {
     // Compile body — returns +1 Value(TAG_FUNC) wrapping a JitClosure.
     // Pass `name` so introspection (fn.name) reflects the source-level
     // identifier rather than the internal __culebra_fn_N symbol.
+    // Seed class_type_params_ with this fn's own Generic params so
+    // compile_fn_common neutralizes `T` in the param type_checks (it
+    // moves+clears class_type_params_, so nested fns don't inherit).
+    class_type_params_ = mf_type_params;
     auto bodyVal = compile_fn_common(&ast, *params_ast, body_ast, returnType,
                                       name);
 
@@ -12147,8 +12159,14 @@ struct JIT {
       auto t = extract_type_annotation(*p, 2);
       if (t.empty()) {
         typePtrs.push_back(llvm::ConstantPointerNull::get(ptrTy));
-      } else {
+      } else if (mf_type_params.empty()) {
         typePtrs.push_back(get_or_create_global_str(t, ".pt"));
+      } else {
+        // Lower bare `T` / `Array<T>` to "Any" / bound trait so the
+        // dispatch key matches on the bound (or accepts anything for an
+        // unbounded T). Mirrors interp's method.param_types.
+        typePtrs.push_back(get_or_create_global_str(
+            culebra::lower_type_params(t, mf_type_params), ".pt"));
       }
     }
     auto n_param_types = static_cast<int64_t>(typePtrs.size());
@@ -12280,7 +12298,7 @@ struct JIT {
     }
 
     std::vector<std::string> paramNames;
-    // Owning std::string so rewrite_type_params_to_any (which returns a
+    // Owning std::string so lower_type_params (which returns a
     // fresh string) is safe to push; downstream consumers (emit_type_check,
     // paramTypeStrs) take string_view and accept either.
     std::vector<std::string> paramTypeNames;
@@ -12317,7 +12335,7 @@ struct JIT {
       // from the immediate enclosing class so nested fns in the body
       // don't inherit the rewrite (matches interp).
       if (!active_class_type_params.empty() && !tname.empty()) {
-        tname = culebra::rewrite_type_params_to_any(
+        tname = culebra::lower_type_params(
             tname, active_class_type_params);
       }
       paramTypeNames.push_back(tname);

--- a/include/parser.h
+++ b/include/parser.h
@@ -15,7 +15,7 @@ namespace culebra {
 const auto grammar_ = R"(
   PROGRAM                  <-  _ STATEMENTS _
   STATEMENTS               <-  (STATEMENT (_sp_ (';' / _nl_) (_ STATEMENT)?)*)?
-  STATEMENT                <-  DEBUGGER / RETURN / THROW / YIELD / BREAK / CONTINUE / DEFER / IMPORT_STMT / EXPORT_STMT / MULTIFN_DECL / CLASS_DECL / TRAIT_DECL / LEXICAL_SCOPE / EXPRESSION
+  STATEMENT                <-  DEBUGGER / RETURN / THROW / YIELD_FROM / YIELD / BREAK / CONTINUE / DEFER / IMPORT_STMT / EXPORT_STMT / MULTIFN_DECL / CLASS_DECL / TRAIT_DECL / LEXICAL_SCOPE / EXPRESSION
 
   # Module system (§25). `import name from "./path"` binds the file's
   # `export { ... }` value to `name`. String-literal paths only.
@@ -68,6 +68,7 @@ const auto grammar_ = R"(
   DEBUGGER                 <-  debugger
   RETURN                   <-  return (_sp_ !_nl_ EXPRESSION)?
   THROW                    <-  throw _sp_ !_nl_ EXPRESSION
+  YIELD_FROM               <-  yield _sp_ from _sp_ !_nl_ EXPRESSION                  { no_ast_opt }
   YIELD                    <-  yield _sp_ !_nl_ EXPRESSION                            { no_ast_opt }
   BREAK                    <-  break
   CONTINUE                 <-  continue
@@ -656,7 +657,7 @@ inline std::shared_ptr<peg::Ast> parse(const std::string& path,
         true, {"PARAMETERS", "LAMBDA_PARAMS", "SEQUENCE", "OBJECT",
                "OBJECT_PROPERTY", "TUPLE", "SET",
                "ARRAY", "RETURN",
-               "THROW", "YIELD", "TRY", "DEFER",
+               "THROW", "YIELD", "YIELD_FROM", "TRY", "DEFER",
                "LEXICAL_SCOPE", "TYPE_ANNOTATION", "RETURN_TYPE",
                "DEFAULT_VALUE",
                "ARG_LIST", "KWARG", "KWARG_SPLAT",

--- a/include/parser.h
+++ b/include/parser.h
@@ -48,10 +48,11 @@ const auto grammar_ = R"(
   # `Box`, `Box<T>`, `Pair<K, V>`, `sort<T: Comparable>`. Captured into
   # a single token; eval_class_decl / eval_trait_decl / multifn_decl
   # peel off the outer name via parse_generic_head, then split args
-  # into per-param `name: bound` pairs via parse_type_param.
-  # Type parameters are documentation in the MVP — runtime sees them
-  # as Any-equivalent (bound check is dispatch-time only).
-  CLASS_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* )? )* _sp_ '>' )? >
+  # into per-param `name: bound` pairs via parse_type_param. A bound
+  # may be composite (`T: Hashable + Stringer`, all-of). Unbounded
+  # params lower to Any; bounded ones lower to the bound trait(s) and
+  # are enforced at dispatch / type_check time.
+  CLASS_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? )* _sp_ '>' )? >
 
   # `@expr` before a `fn` / `class` declaration. The expression is any
   # CALL chain (`@deco`, `@deco(arg)`, `@module.deco(arg)`); it must

--- a/include/parser.h
+++ b/include/parser.h
@@ -68,7 +68,7 @@ const auto grammar_ = R"(
   DEBUGGER                 <-  debugger
   RETURN                   <-  return (_sp_ !_nl_ EXPRESSION)?
   THROW                    <-  throw _sp_ !_nl_ EXPRESSION
-  YIELD                    <-  yield _sp_ !_nl_ EXPRESSION
+  YIELD                    <-  yield _sp_ !_nl_ EXPRESSION                            { no_ast_opt }
   BREAK                    <-  break
   CONTINUE                 <-  continue
   DEFER                    <-  defer _ BLOCK

--- a/include/parser.h
+++ b/include/parser.h
@@ -132,7 +132,7 @@ const auto grammar_ = R"(
   SEQUENCE                 <-  (EXPRESSION (_ ',' _ EXPRESSION)*)?
 
   WHILE                    <-  while _ EXPRESSION _ BLOCK
-  FOR                      <-  for _ IDENTIFIER _ in _ EXPRESSION _ BLOCK
+  FOR                      <-  for _ IDENTIFIER _ in _ EXPRESSION _ BLOCK         { no_ast_opt }
   IF                       <-  if _ EXPRESSION _ BLOCK (_ else _ if _ EXPRESSION _ BLOCK)* (_ else _ BLOCK)?
 
   MATCH                    <-  match _ EXPRESSION _ '{' _ MATCH_ARMS _ '}'
@@ -657,7 +657,7 @@ inline std::shared_ptr<peg::Ast> parse(const std::string& path,
         true, {"PARAMETERS", "LAMBDA_PARAMS", "SEQUENCE", "OBJECT",
                "OBJECT_PROPERTY", "TUPLE", "SET",
                "ARRAY", "RETURN",
-               "THROW", "YIELD", "YIELD_FROM", "TRY", "DEFER",
+               "THROW", "YIELD", "YIELD_FROM", "TRY", "DEFER", "FOR",
                "LEXICAL_SCOPE", "TYPE_ANNOTATION", "RETURN_TYPE",
                "DEFAULT_VALUE",
                "ARG_LIST", "KWARG", "KWARG_SPLAT",

--- a/include/parser.h
+++ b/include/parser.h
@@ -37,7 +37,7 @@ const auto grammar_ = R"(
   # conformance: any class whose own methods cover the required ones
   # (arity match) is treated as conforming automatically — no `impl`
   # block needed in this MVP.
-  TRAIT_DECL               <-  (DECORATOR (_ DECORATOR)* _)? trait _ CLASS_HEAD _ '{' _ (TRAIT_METHOD (_ TRAIT_METHOD)*)? _ '}'
+  TRAIT_DECL               <-  (DECORATOR (_ DECORATOR)* _)? trait _ TRAIT_HEAD _ '{' _ (TRAIT_METHOD (_ TRAIT_METHOD)*)? _ '}'
   TRAIT_METHOD             <-  IDENTIFIER _ PARAMETERS (_ RETURN_TYPE)? (_ TRAIT_BODY)?
   # TRAIT_BODY wraps BLOCK so AstOptimizer keeps a distinct node
   # indicating "this method has a default impl" — BLOCK itself is
@@ -53,6 +53,11 @@ const auto grammar_ = R"(
   # params lower to Any; bounded ones lower to the bound trait(s) and
   # are enforced at dispatch / type_check time.
   CLASS_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? )* _sp_ '>' )? >
+  # Trait declaration head: CLASS_HEAD plus an optional supertrait list
+  # (`trait Ord: Eq`, `trait Cmp<T>: Eq, Show`). Captured as one token;
+  # parse_trait_head splits the name (with generics) from the comma-
+  # separated supertraits, whose methods are flattened into the trait.
+  TRAIT_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? )* _sp_ '>' )? ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? >
 
   # `@expr` before a `fn` / `class` declaration. The expression is any
   # CALL chain (`@deco`, `@deco(arg)`, `@module.deco(arg)`); it must

--- a/include/shared.h
+++ b/include/shared.h
@@ -384,6 +384,34 @@ inline TypeParam parse_type_param(std::string_view raw) {
           trim_ascii(trimmed.substr(pos + 1))};
 }
 
+// Split a TRAIT_HEAD token into the trait name (with any Generic
+// params still attached) and its supertrait list. `Ord: Eq` →
+// {"Ord", ["Eq"]}; `Cmp<T>: Eq, Show` → {"Cmp<T>", ["Eq", "Show"]};
+// `Foo` → {"Foo", {}}. The name/supertrait split is on the first `:`
+// at bracket depth 0 so a type-param bound (`Box<T: Bound>`) inside
+// `<...>` is not mistaken for the supertrait separator. Each view
+// aliases `token` — keep it alive (do not pass a temporary).
+struct TraitHead {
+  std::string_view name;                     // may include `<...>`
+  std::vector<std::string_view> supertraits;
+};
+inline TraitHead parse_trait_head(std::string_view token) {
+  auto trimmed = trim_ascii(token);
+  int depth = 0;
+  size_t colon = std::string_view::npos;
+  for (size_t i = 0; i < trimmed.size(); i++) {
+    char c = trimmed[i];
+    if (c == '<') depth++;
+    else if (c == '>') { if (depth > 0) depth--; }
+    else if (c == ':' && depth == 0) { colon = i; break; }
+  }
+  if (colon == std::string_view::npos) return {trimmed, {}};
+  TraitHead out;
+  out.name = trim_ascii(trimmed.substr(0, colon));
+  out.supertraits = split_generic_args(trimmed.substr(colon + 1));
+  return out;
+}
+
 // Lower every occurrence of a type-param name (`T`, `K`, ...) inside
 // `tn` to its runtime check target, including nested forms like
 // `Array<T>` and `T | Long`. An *unbounded* param (`T`) lowers to
@@ -658,6 +686,11 @@ struct TraitMethod {
 struct TraitDef {
   std::string name;
   std::vector<TraitMethod> methods;
+  // Supertrait names (`trait Ord: Eq` → {"Eq"}); their methods are
+  // flattened into `methods` at register_trait time so conformance and
+  // dispatch stay single-set look-ups. Empty on the JIT/AOT path, which
+  // flattens at runtime via culebra_runtime_register_trait_super.
+  std::vector<std::string> supertraits;
 };
 
 // Process-wide registry. Trait declarations register here; type_matches
@@ -687,8 +720,28 @@ trait_conformance_cache() {
   return cache;
 }
 
+// Merge a supertrait's methods into `def` (dedup by name, keeping
+// `def`'s own entries). The supertrait must already be registered —
+// declaration order guarantees this for `trait Ord: Eq`. Unknown
+// supers are silently skipped (best-effort). Caller holds trait_mutex().
+inline void merge_supertrait_into(TraitDef& def, const std::string& super) {
+  auto& reg = trait_registry();
+  auto it = reg.find(super);
+  if (it == reg.end()) return;
+  for (const auto& m : it->second.methods) {
+    bool present = false;
+    for (const auto& e : def.methods)
+      if (e.name == m.name) { present = true; break; }
+    if (!present) def.methods.push_back(m);
+  }
+}
+
 inline void register_trait(TraitDef def) {
   std::unique_lock lock(trait_mutex());
+  // Flatten supertrait methods (trait inheritance) so conformance is a
+  // single-set check. JIT/AOT carries empty supertraits and instead
+  // merges via culebra_runtime_register_trait_super after registration.
+  for (const auto& super : def.supertraits) merge_supertrait_into(def, super);
   trait_registry()[def.name] = std::move(def);
   trait_conformance_cache().clear();
 }

--- a/include/shared.h
+++ b/include/shared.h
@@ -260,6 +260,47 @@ inline std::vector<std::string_view> split_union_types(
   return out;
 }
 
+// True iff `name` has a `+` at the outermost bracket depth — the
+// intersection separator used in composite Generic bounds
+// (`T: Hashable + Stringer`, lowered to `"Hashable + Stringer"`).
+// Depth-aware to mirror has_toplevel_pipe, though bound atoms are
+// bare trait names today and never carry `<...>`.
+inline bool has_toplevel_plus(std::string_view name) {
+  int depth = 0;
+  for (char c : name) {
+    if (c == '<') depth++;
+    else if (c == '>') { if (depth > 0) depth--; }
+    else if (c == '+' && depth == 0) return true;
+  }
+  return false;
+}
+
+// Split a `+`-separated intersection bound into its component trait
+// names. `Hashable + Stringer` → ["Hashable", "Stringer"]. A value
+// satisfies the bound when it conforms to *all* parts (all-of), the
+// dual of split_union_types' any-of. Whitespace is trimmed; empty
+// parts are skipped. Mirrors split_union_types (incl. LIFETIME: each
+// view aliases `name`, so don't pass a temporary).
+inline std::vector<std::string_view> split_intersection_types(
+    std::string_view name) {
+  std::vector<std::string_view> out;
+  size_t start = 0;
+  int depth = 0;
+  for (size_t i = 0; i < name.size(); i++) {
+    char c = name[i];
+    if (c == '<') depth++;
+    else if (c == '>') { if (depth > 0) depth--; }
+    else if (c == '+' && depth == 0) {
+      auto cand = trim_ascii(name.substr(start, i - start));
+      if (!cand.empty()) out.push_back(cand);
+      start = i + 1;
+    }
+  }
+  auto last = trim_ascii(name.substr(start));
+  if (!last.empty()) out.push_back(last);
+  return out;
+}
+
 // Split a comma-separated Generic argument list into its components,
 // respecting nested `<...>`. `Long, Map<String, Long>` →
 // ["Long", "Map<String, Long>"]. Empty args yield empty vector.
@@ -376,8 +417,21 @@ inline std::string lower_type_params(
   // the generic args were documentation anyway).
   for (auto tp_raw : type_params) {
     auto tp = parse_type_param(tp_raw);
-    if (head.outer == tp.name)
-      return tp.bound.empty() ? "Any" : std::string(tp.bound);
+    if (head.outer != tp.name) continue;
+    if (tp.bound.empty()) return "Any";
+    // Composite bound (`A + B`): normalize spacing to a canonical
+    // " + "-joined form so dispatch-key dedup compares equal regardless
+    // of source whitespace. Matching itself is spacing-insensitive
+    // (split_intersection_types trims), but the registered key isn't.
+    if (!has_toplevel_plus(tp.bound)) return std::string(tp.bound);
+    std::string out;
+    bool first = true;
+    for (auto part : split_intersection_types(tp.bound)) {
+      if (!first) out += " + ";
+      out += part;
+      first = false;
+    }
+    return out;
   }
   if (head.args.empty()) return std::string(head.outer);
   // Generic: keep outer, recurse into each arg.

--- a/include/shared.h
+++ b/include/shared.h
@@ -777,6 +777,7 @@ trait Hashable {
 trait Iterator {
   has_next() -> Bool
   next() -> Any
+  dispose() {}
 }
 trait Iterable {
   iter() -> Iterator

--- a/include/shared.h
+++ b/include/shared.h
@@ -343,13 +343,17 @@ inline TypeParam parse_type_param(std::string_view raw) {
           trim_ascii(trimmed.substr(pos + 1))};
 }
 
-// Rewrite every occurrence of a class type-param name (`T`, `K`, ...)
-// inside `tn` with "Any", including nested forms like `Array<T>` and
-// `T | Long`. Used by class-method neutralization so the runtime type
-// check is no-op for the documented parameters. Returns the rewritten
-// string in canonical form (single-space `|`, comma-space-separated
-// generic args).
-inline std::string rewrite_type_params_to_any(
+// Lower every occurrence of a type-param name (`T`, `K`, ...) inside
+// `tn` to its runtime check target, including nested forms like
+// `Array<T>` and `T | Long`. An *unbounded* param (`T`) lowers to
+// "Any" (the annotation was documentation, so the check is a no-op).
+// A *bounded* param (`T: Comparable`) lowers to its bound trait name
+// (`Comparable`) so the existing trait-conformance machinery enforces
+// the bound at dispatch / type_check time — no separate generic
+// dispatch path is needed. Used by both class-method and free-fn
+// signature neutralization. Returns the result in canonical form
+// (single-space `|`, comma-space-separated generic args).
+inline std::string lower_type_params(
     std::string_view tn,
     const std::vector<std::string_view>& type_params) {
   auto trimmed = trim_ascii(tn);
@@ -360,18 +364,20 @@ inline std::string rewrite_type_params_to_any(
     bool first = true;
     for (auto cand : split_union_types(trimmed)) {
       if (!first) out += " | ";
-      out += rewrite_type_params_to_any(cand, type_params);
+      out += lower_type_params(cand, type_params);
       first = false;
     }
     return out;
   }
   auto head = parse_generic_head(trimmed);
-  // Outer alone matches a type-param: the whole annotation becomes Any
-  // (so `T`, `T<Long>`, etc. all collapse to "Any" — the args were
-  // documentation anyway). Type-params may carry a bound (`T: Foo`);
-  // strip via parse_type_param so comparison sees just the name.
+  // Outer alone matches a type-param: the whole annotation collapses to
+  // the param's lowered form (so `T`, `T<Long>`, etc. all become "Any"
+  // for an unbounded param, or the bound trait name for a bounded one —
+  // the generic args were documentation anyway).
   for (auto tp_raw : type_params) {
-    if (head.outer == parse_type_param(tp_raw).name) return "Any";
+    auto tp = parse_type_param(tp_raw);
+    if (head.outer == tp.name)
+      return tp.bound.empty() ? "Any" : std::string(tp.bound);
   }
   if (head.args.empty()) return std::string(head.outer);
   // Generic: keep outer, recurse into each arg.
@@ -380,7 +386,7 @@ inline std::string rewrite_type_params_to_any(
   bool first = true;
   for (auto a : split_generic_args(head.args)) {
     if (!first) out += ", ";
-    out += rewrite_type_params_to_any(a, type_params);
+    out += lower_type_params(a, type_params);
     first = false;
   }
   out += '>';

--- a/justfile
+++ b/justfile
@@ -11,14 +11,24 @@ default:
 build *extra:
     mkdir -p build
     cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCULEBRA_ENABLE_JIT=ON {{extra}} .. > /dev/null
-    cd build && make
+    cd build && make -j$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
+
+# Fast dev build: LTO off (saves ~15-25 s link), still Release + JIT,
+# uses a separate `build-dev/` so it doesn't fight `just build`'s cache.
+# Pair with ccache (auto-detected by CMake) for near-instant rebuilds
+# when only ephemeral mtimes changed.
+[group("build")]
+dev *extra:
+    mkdir -p build-dev
+    cd build-dev && cmake -DCMAKE_BUILD_TYPE=Release -DCULEBRA_ENABLE_JIT=ON -DCULEBRA_LTO=OFF {{extra}} .. > /dev/null
+    cd build-dev && make -j$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8) culebra
 
 # Build without JIT (interpreter only, no LLVM)
 [group("build")]
 build-no-jit:
     mkdir -p build
     cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCULEBRA_ENABLE_JIT=OFF .. > /dev/null
-    cd build && make
+    cd build && make -j$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
 
 # Clean build directory
 [group("build")]

--- a/misc/culebra.peg
+++ b/misc/culebra.peg
@@ -1,6 +1,6 @@
   PROGRAM                  <-  _ STATEMENTS _
   STATEMENTS               <-  (STATEMENT (_sp_ (';' / _nl_) (_ STATEMENT)?)*)?
-  STATEMENT                <-  DEBUGGER / RETURN / THROW / YIELD / BREAK / CONTINUE / DEFER / IMPORT_STMT / EXPORT_STMT / MULTIFN_DECL / CLASS_DECL / TRAIT_DECL / LEXICAL_SCOPE / EXPRESSION
+  STATEMENT                <-  DEBUGGER / RETURN / THROW / YIELD_FROM / YIELD / BREAK / CONTINUE / DEFER / IMPORT_STMT / EXPORT_STMT / MULTIFN_DECL / CLASS_DECL / TRAIT_DECL / LEXICAL_SCOPE / EXPRESSION
 
   # Module system (§25). `import name from "./path"` binds the file's
   # `export { ... }` value to `name`. String-literal paths only.
@@ -53,6 +53,7 @@
   DEBUGGER                 <-  debugger
   RETURN                   <-  return (_sp_ !_nl_ EXPRESSION)?
   THROW                    <-  throw _sp_ !_nl_ EXPRESSION
+  YIELD_FROM               <-  yield _sp_ from _sp_ !_nl_ EXPRESSION                  { no_ast_opt }
   YIELD                    <-  yield _sp_ !_nl_ EXPRESSION                            { no_ast_opt }
   BREAK                    <-  break
   CONTINUE                 <-  continue

--- a/misc/culebra.peg
+++ b/misc/culebra.peg
@@ -53,7 +53,7 @@
   DEBUGGER                 <-  debugger
   RETURN                   <-  return (_sp_ !_nl_ EXPRESSION)?
   THROW                    <-  throw _sp_ !_nl_ EXPRESSION
-  YIELD                    <-  yield _sp_ !_nl_ EXPRESSION
+  YIELD                    <-  yield _sp_ !_nl_ EXPRESSION                            { no_ast_opt }
   BREAK                    <-  break
   CONTINUE                 <-  continue
   DEFER                    <-  defer _ BLOCK

--- a/misc/culebra.peg
+++ b/misc/culebra.peg
@@ -22,7 +22,7 @@
   # conformance: any class whose own methods cover the required ones
   # (arity match) is treated as conforming automatically — no `impl`
   # block needed in this MVP.
-  TRAIT_DECL               <-  (DECORATOR (_ DECORATOR)* _)? trait _ CLASS_HEAD _ '{' _ (TRAIT_METHOD (_ TRAIT_METHOD)*)? _ '}'
+  TRAIT_DECL               <-  (DECORATOR (_ DECORATOR)* _)? trait _ TRAIT_HEAD _ '{' _ (TRAIT_METHOD (_ TRAIT_METHOD)*)? _ '}'
   TRAIT_METHOD             <-  IDENTIFIER _ PARAMETERS (_ RETURN_TYPE)? (_ TRAIT_BODY)?
   # TRAIT_BODY wraps BLOCK so AstOptimizer keeps a distinct node
   # indicating "this method has a default impl" — BLOCK itself is
@@ -38,6 +38,11 @@
   # params lower to Any; bounded ones lower to the bound trait(s) and
   # are enforced at dispatch / type_check time.
   CLASS_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? )* _sp_ '>' )? >
+  # Trait declaration head: CLASS_HEAD plus an optional supertrait list
+  # (`trait Ord: Eq`, `trait Cmp<T>: Eq, Show`). Captured as one token;
+  # parse_trait_head splits the name (with generics) from the comma-
+  # separated supertraits, whose methods are flattened into the trait.
+  TRAIT_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? )* _sp_ '>' )? ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? >
 
   # `@expr` before a `fn` / `class` declaration. The expression is any
   # CALL chain (`@deco`, `@deco(arg)`, `@module.deco(arg)`); it must

--- a/misc/culebra.peg
+++ b/misc/culebra.peg
@@ -117,7 +117,7 @@
   SEQUENCE                 <-  (EXPRESSION (_ ',' _ EXPRESSION)*)?
 
   WHILE                    <-  while _ EXPRESSION _ BLOCK
-  FOR                      <-  for _ IDENTIFIER _ in _ EXPRESSION _ BLOCK
+  FOR                      <-  for _ IDENTIFIER _ in _ EXPRESSION _ BLOCK         { no_ast_opt }
   IF                       <-  if _ EXPRESSION _ BLOCK (_ else _ if _ EXPRESSION _ BLOCK)* (_ else _ BLOCK)?
 
   MATCH                    <-  match _ EXPRESSION _ '{' _ MATCH_ARMS _ '}'

--- a/misc/culebra.peg
+++ b/misc/culebra.peg
@@ -33,10 +33,11 @@
   # `Box`, `Box<T>`, `Pair<K, V>`, `sort<T: Comparable>`. Captured into
   # a single token; eval_class_decl / eval_trait_decl / multifn_decl
   # peel off the outer name via parse_generic_head, then split args
-  # into per-param `name: bound` pairs via parse_type_param.
-  # Type parameters are documentation in the MVP — runtime sees them
-  # as Any-equivalent (bound check is dispatch-time only).
-  CLASS_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* )? )* _sp_ '>' )? >
+  # into per-param `name: bound` pairs via parse_type_param. A bound
+  # may be composite (`T: Hashable + Stringer`, all-of). Unbounded
+  # params lower to Any; bounded ones lower to the bound trait(s) and
+  # are enforced at dispatch / type_check time.
+  CLASS_HEAD               <-  < IdentInitChar IdentChar* ( _sp_ '<' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? ( _sp_ ',' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ ':' _sp_ [A-Z] [a-zA-Z_0-9]* ( _sp_ '+' _sp_ [A-Z] [a-zA-Z_0-9]* )* )? )* _sp_ '>' )? >
 
   # `@expr` before a `fn` / `class` declaration. The expression is any
   # CALL chain (`@deco`, `@deco(arg)`, `@module.deco(arg)`); it must

--- a/tests/test_builtin_name_fields.cul
+++ b/tests/test_builtin_name_fields.cul
@@ -1,0 +1,60 @@
+// Regression: class fields and generator bindings whose name collides
+// with a builtin method (size / keys / ...) must work, not crash.
+//
+// Two distinct bugs were fixed together:
+//   (1) interp `this.<name> = v` routed a fresh field through assign()
+//       instead of initialize() because has() counts builtin methods —
+//       so `this.size = n` looked like an existing slot and crashed.
+//   (2) the generator transform's rewrite_locals_to_this rewrote the
+//       method name in `arr.size()` to `arr.this.size()` when a param
+//       was named `size`, producing malformed source.
+
+// --- (1) class field named after a builtin method ---
+class Box {
+  new(n) { this.size = n; this.keys = n + 1 }
+  total() { return this.size + this.keys }
+}
+let b = Box.new(10)
+assert_eq(b.size, 10)        // field shadows the builtin size()
+assert_eq(b.keys, 11)
+assert_eq(b.total(), 21)
+
+// reassignment to a builtin-named field
+b.size = 20
+assert_eq(b.size, 20)
+
+// compound assignment to a builtin-named field
+b.size = b.size + 5
+assert_eq(b.size, 25)
+
+// --- bare objects still expose the builtin method (no shadowing) ---
+let o = {a: 1, b: 2, c: 3}
+assert_eq(o.size(), 3)
+assert_eq(o.keys().size(), 3)
+
+// --- (2) generator param named after a builtin method, body calls it ---
+fn take_n(arr, size) {
+  mut i = 0
+  while i < size {
+    yield arr.size()
+    i = i + 1
+  }
+}
+let r = take_n([10, 20, 30], 2).collect()
+assert_eq(r.size(), 2)
+assert_eq(r[0], 3)           // arr.size() == 3, not rewritten to arr.this.size()
+assert_eq(r[1], 3)
+
+// --- generator local named after a builtin method ---
+fn gen_keys() {
+  mut keys = 0
+  while keys < 3 {
+    yield keys
+    keys = keys + 1
+  }
+}
+let k = gen_keys().collect()
+assert_eq(k.size(), 3)
+assert_eq(k[2], 2)
+
+IO.puts('test_builtin_name_fields OK')

--- a/tests/test_generator.cul
+++ b/tests/test_generator.cul
@@ -156,4 +156,72 @@ assert_eq(alt[1], -1)
 assert_eq(alt[2], 2)
 assert_eq(alt[3], -3)
 
+// --- Stage 5: yield inside a for-in loop ---
+fn from_array(arr) {
+  for v in arr {
+    yield v + 1
+  }
+}
+let mapped_s5 = from_array([10, 20, 30]).collect()
+assert_eq(mapped_s5.size(), 3)
+assert_eq(mapped_s5[0], 11)
+assert_eq(mapped_s5[2], 31)
+
+// --- for-in over a generator (nested generator) ---
+fn inner_n(n) {
+  mut i = 0
+  while i < n {
+    yield i
+    i = i + 1
+  }
+}
+fn outer_times10(n) {
+  for x in inner_n(n) {
+    yield x * 10
+  }
+}
+let nested = outer_times10(4).collect()
+assert_eq(nested.size(), 4)
+assert_eq(nested[0], 0)
+assert_eq(nested[1], 10)
+assert_eq(nested[3], 30)
+
+// --- for-in with conditional yield (Stage 3 + Stage 5 combined) ---
+fn keep_evens(arr) {
+  for v in arr {
+    if v % 2 == 0 {
+      yield v
+    }
+  }
+}
+let evens_s5 = keep_evens([1, 2, 3, 4, 5, 6]).collect()
+assert_eq(evens_s5.size(), 3)
+assert_eq(evens_s5[0], 2)
+assert_eq(evens_s5[2], 6)
+
+// --- for-in with both arms yielding ---
+fn signed_evens(arr) {
+  for v in arr {
+    if v % 2 == 0 {
+      yield v
+    } else {
+      yield -v
+    }
+  }
+}
+let se = signed_evens([1, 2, 3, 4]).collect()
+assert_eq(se.size(), 4)
+assert_eq(se[0], -1)
+assert_eq(se[1], 2)
+assert_eq(se[2], -3)
+assert_eq(se[3], 4)
+
+// --- early break still works through the for-in path ---
+mut sum_s5 = 0
+for x in outer_times10(100) {
+  sum_s5 = sum_s5 + x
+  if x >= 30 { break }
+}
+assert_eq(sum_s5, 0 + 10 + 20 + 30)
+
 IO.puts('test_generator OK')

--- a/tests/test_generator_complex.cul
+++ b/tests/test_generator_complex.cul
@@ -1,0 +1,70 @@
+// CPS spike: generators whose control flow exceeds the Stage 3
+// "single terminal loop, single yield-bearing stmt" shape.
+//   - post-loop yield   (chunk / group_by tail flush)
+//   - code after yield within a branch (chunk's `yield buf; buf = []`)
+//   - multiple yields per loop iteration (intersperse)
+// Index-based assertions (Array equality is identity).
+
+// --- chunk: fixed-size groups + remainder flush after the loop ---
+fn chunk(arr, n) {
+  mut buf = []
+  for v in arr {
+    buf.push(v)
+    if buf.size() >= n {
+      yield buf
+      buf = []
+    }
+  }
+  if buf.size() > 0 { yield buf }
+}
+let c = chunk([1, 2, 3, 4, 5], 2).collect()
+assert_eq(c.size(), 3)
+assert_eq(c[0].size(), 2)
+assert_eq(c[0][0], 1)
+assert_eq(c[1][1], 4)
+assert_eq(c[2].size(), 1)
+assert_eq(c[2][0], 5)
+
+// chunk dividing evenly (no tail) ---
+let c2 = chunk([1, 2, 3, 4], 2).collect()
+assert_eq(c2.size(), 2)
+assert_eq(c2[1][1], 4)
+
+// --- group_consecutive: flush last run after the loop ---
+fn group_consecutive(arr) {
+  mut cur = []
+  mut key = nil
+  for v in arr {
+    if cur.size() > 0 && v != key {
+      yield cur
+      cur = []
+    }
+    cur.push(v)
+    key = v
+  }
+  if cur.size() > 0 { yield cur }
+}
+let g = group_consecutive([1, 1, 2, 3, 3, 3]).collect()
+assert_eq(g.size(), 3)
+assert_eq(g[0].size(), 2)
+assert_eq(g[1].size(), 1)
+assert_eq(g[2].size(), 3)
+
+// --- intersperse: two yields per iteration ---
+fn intersperse(arr, sep) {
+  mut first = true
+  for v in arr {
+    if !first { yield sep }
+    yield v
+    first = false
+  }
+}
+let s = intersperse([1, 2, 3], 0).collect()
+assert_eq(s.size(), 5)
+assert_eq(s[0], 1)
+assert_eq(s[1], 0)
+assert_eq(s[2], 2)
+assert_eq(s[3], 0)
+assert_eq(s[4], 3)
+
+IO.puts('test_generator_complex OK')

--- a/tests/test_generator_resource.cul
+++ b/tests/test_generator_resource.cul
@@ -1,0 +1,114 @@
+// Stage 6a: resource-safe generator via dispose protocol + defer + C# rule.
+//
+// Verifies that `defer { ... }` blocks inside generator bodies run reliably:
+//   - on natural drain (loop iteration completes)
+//   - on early `break` out of for-in
+//   - on exception thrown inside the for-in body
+//   - exactly once (idempotent against explicit `.dispose()`)
+// Plus the Stage 3 pre-yield-position try/catch bug fix.
+//
+// Uses a mut String trace + interpolation (no array equality, no `+`
+// concat between Strings) — same pattern as tests/test_defer.cul.
+
+// --- (1) Built-in iterators still work (default dispose = no-op) ---
+mut sum = 0
+for v in [1, 2, 3] { sum = sum + v }
+assert_eq(sum, 6)
+
+// --- (2) defer runs on natural drain ---
+mut log_a = ''
+fn gen_a() {
+  defer { log_a = "{log_a}closed;" }
+  for v in [1, 2, 3] { yield v }
+}
+for v in gen_a() { log_a = "{log_a}{v};" }
+assert_eq(log_a, '1;2;3;closed;')
+
+// --- (3) defer runs on early `break` ---
+mut log_b = ''
+fn gen_b() {
+  defer { log_b = "{log_b}closed;" }
+  mut i = 0
+  while i < 100 {
+    yield i
+    i = i + 1
+  }
+}
+for v in gen_b() {
+  log_b = "{log_b}{v};"
+  if v >= 2 { break }
+}
+assert_eq(log_b, '0;1;2;closed;')
+
+// --- (4) multiple defers run in LIFO order ---
+mut log_c = ''
+fn gen_c() {
+  defer { log_c = "{log_c}c1;" }
+  defer { log_c = "{log_c}c2;" }
+  defer { log_c = "{log_c}c3;" }
+  for v in [42] { yield v }
+}
+for v in gen_c() { log_c = "{log_c}{v};" }
+assert_eq(log_c, '42;c3;c2;c1;')
+
+// --- (5) explicit dispose is idempotent; defer fires exactly once ---
+mut log_d = ''
+fn gen_d() {
+  defer { log_d = "{log_d}once;" }
+  for v in [1, 2] { yield v }
+}
+let g_d = gen_d()
+for v in g_d { log_d = "{log_d}{v};" }
+g_d.dispose()                    // explicit second call — must be no-op
+g_d.dispose()                    // and a third
+assert_eq(log_d, '1;2;once;')
+
+// --- (6) defer runs on exception thrown inside for-in body ---
+mut log_e = ''
+fn gen_e() {
+  defer { log_e = "{log_e}closed;" }
+  for v in [1, 2, 3] { yield v }
+}
+try {
+  for v in gen_e() {
+    log_e = "{log_e}{v};"
+    if v == 1 { throw 'boom' }
+  }
+} catch e { log_e = "{log_e}caught;" }
+assert_eq(log_e, '1;closed;caught;')
+
+// --- (7) defer accesses locals set during body execution ---
+// The defer { f.close() } pattern: `f` is a local set by `let f = ...`
+// before the defer registration is reached. At dispose time, f is the
+// open resource; the closure sees the current value via `this.f`.
+mut log_f = ''
+class FakeResource {
+  new(name) { this.name = name }
+  close() { log_f = "{log_f}close:{this.name};" }
+}
+fn gen_f() {
+  let f = FakeResource.new('alpha')
+  defer { f.close() }
+  for v in [10, 20] { yield v }
+}
+for v in gen_f() { log_f = "{log_f}{v};" }
+assert_eq(log_f, '10;20;close:alpha;')
+
+// --- (8) Stage 3 pre-yield try/catch ---
+// Pre-yield position try/catch with a mut binding mutated inside both
+// the try and the catch arms should hand the post-try value to the
+// downstream yield.
+fn classify(arr) {
+  for v in arr {
+    mut tag = nil
+    try { tag = to_string(100 / v) } catch e { tag = 'err' }
+    yield tag
+  }
+}
+let cls = classify([5, 0, 20]).collect()
+assert_eq(cls.size(), 3)
+assert_eq(cls[0], '20')
+assert_eq(cls[1], 'err')
+assert_eq(cls[2], '5')
+
+IO.puts('test_generator_resource OK')

--- a/tests/test_generator_yield_from.cul
+++ b/tests/test_generator_yield_from.cul
@@ -108,4 +108,24 @@ for l in outer([Leaf.new(1), Leaf.new(2), Leaf.new(3), Leaf.new(4)]) {
 }
 assert_eq(leaf_log, 'v1;v2;')
 
+// --- yield from inside an if/else branch (json_walk recursive flatten) ---
+// Regression: a yielding for-in nested in an if-branch used to inherit the
+// enclosing block's pos/len under AstOptimizer collapse, so the for-in
+// desugar clobbered the branch braces and the fn was left untransformed
+// (silently returned nil). Fixed by `{ no_ast_opt }` on the FOR rule.
+fn json_walk(node) {
+  if type_of(node) == 'Array' {
+    for v in node { yield from json_walk(v) }
+  } else {
+    yield node
+  }
+}
+let jw = json_walk([1, [2, [3, 4]], 5]).collect()
+assert_eq(jw.size(), 5)
+assert_eq(jw[0], 1)
+assert_eq(jw[1], 2)
+assert_eq(jw[2], 3)
+assert_eq(jw[3], 4)
+assert_eq(jw[4], 5)
+
 IO.puts('test_generator_yield_from OK')

--- a/tests/test_generator_yield_from.cul
+++ b/tests/test_generator_yield_from.cul
@@ -1,0 +1,111 @@
+// Stage 6b: yield from delegation via phase machine.
+//
+// Verifies the four patterns the phase machine must handle:
+//   P1 — single `yield from g` at body top level
+//   P2 — sequential `yield from a; yield from b`
+//   P3 — `for x in xs { yield from f(x) }` (delegate inside a for-in)
+//   P4 — bare yield + for-in with yield-from (recursive tree walks)
+//
+// Uses `.collect()` to materialize the iterator and indexes into the
+// resulting Array since culebra Array equality is identity-based.
+
+// --- P1: single yield from ---
+fn passthrough(it) {
+  yield from it
+}
+let p1 = passthrough([10, 20, 30]).collect()
+assert_eq(p1.size(), 3)
+assert_eq(p1[0], 10)
+assert_eq(p1[1], 20)
+assert_eq(p1[2], 30)
+
+// --- P2: sequential yield from ---
+fn chain2(a, b) {
+  yield from a
+  yield from b
+}
+let p2 = chain2([1, 2], [3, 4, 5]).collect()
+assert_eq(p2.size(), 5)
+assert_eq(p2[0], 1)
+assert_eq(p2[1], 2)
+assert_eq(p2[2], 3)
+assert_eq(p2[3], 4)
+assert_eq(p2[4], 5)
+
+// --- yield from a generator (delegation chain) ---
+fn counter(n) {
+  mut i = 0
+  while i < n {
+    yield i
+    i = i + 1
+  }
+}
+fn double_counter(n) {
+  yield from counter(n)
+}
+let dc = double_counter(3).collect()
+assert_eq(dc.size(), 3)
+assert_eq(dc[0], 0)
+assert_eq(dc[1], 1)
+assert_eq(dc[2], 2)
+
+// --- P3: yield from inside for-in ---
+fn flatten(xss) {
+  for xs in xss {
+    yield from xs
+  }
+}
+let p3 = flatten([[1, 2], [3], [4, 5]]).collect()
+assert_eq(p3.size(), 5)
+assert_eq(p3[0], 1)
+assert_eq(p3[1], 2)
+assert_eq(p3[2], 3)
+assert_eq(p3[3], 4)
+assert_eq(p3[4], 5)
+
+// --- P4: bare yield + for-in with yield-from (preorder tree walk) ---
+class TNode {
+  new(val, kids) { this.val = val; this.kids = kids }
+}
+fn preorder(node) {
+  yield node.val
+  for child in node.kids {
+    yield from preorder(child)
+  }
+}
+let tree = TNode.new(1, [
+  TNode.new(2, [
+    TNode.new(4, []),
+    TNode.new(5, [])
+  ]),
+  TNode.new(3, [])
+])
+let pre = preorder(tree).collect()
+assert_eq(pre.size(), 5)
+assert_eq(pre[0], 1)
+assert_eq(pre[1], 2)
+assert_eq(pre[2], 4)
+assert_eq(pre[3], 5)
+assert_eq(pre[4], 3)
+
+// --- yield from cooperates with early break (dispose forwards) ---
+mut leaf_log = ''
+class Leaf {
+  new(id) { this.id = id }
+  visit() { leaf_log = "{leaf_log}v{this.id};" }
+}
+fn visit_leaves(leaves) {
+  for l in leaves {
+    yield l
+  }
+}
+fn outer(leaves) {
+  yield from visit_leaves(leaves)
+}
+for l in outer([Leaf.new(1), Leaf.new(2), Leaf.new(3), Leaf.new(4)]) {
+  l.visit()
+  if l.id == 2 { break }
+}
+assert_eq(leaf_log, 'v1;v2;')
+
+IO.puts('test_generator_yield_from OK')

--- a/tests/test_generic_bound.cul
+++ b/tests/test_generic_bound.cul
@@ -71,4 +71,37 @@ assert_eq(b.get(), 42)
 let e_box = try { b.set([1, 2]); nil } catch e { e }
 assert_eq(e_box != nil, true)            // Array violates T: Comparable
 
+// --- Composite bound `<T: A + B>` (all-of) ---
+fn both<T: Hashable + Stringer>(x: T) { x }
+assert_eq(both(5), 5)          // Long conforms to Hashable AND Stringer
+assert_eq(both("hi"), "hi")    // String conforms to both
+let e_both = try { both([1, 2, 3]); nil } catch e { e }
+assert_eq(e_both != nil, true) // Array is Stringer but not Hashable -> rejected
+
+// Overload: concrete > composite-bounded > unbounded.
+fn kc(x: Long) { "concrete" }
+fn kc<T: Hashable + Stringer>(x: T) { "composite" }
+fn kc<T>(x: T) { "unbounded" }
+assert_eq(kc(5), "concrete")
+assert_eq(kc("s"), "composite")   // String conforms to both bounds
+assert_eq(kc([1]), "unbounded")   // Array conforms to neither
+
+// User class conforming to both built-in traits.
+class Tag {
+  new(n) { this.n = n }
+  hash() { this.n }
+  to_s() { "Tag" }
+}
+fn need_both<T: Hashable + Stringer>(x: T) { x.n }
+assert_eq(need_both(Tag.new(7)), 7)
+
+// User class missing one part is rejected.
+class HashOnly { new(n) { this.n = n } hash() { this.n } }
+let e_ho = try { need_both(HashOnly.new(1)); nil } catch e { e }
+assert_eq(e_ho != nil, true)
+
+// Spacing tolerance: no-space `<T:A+B>` parses and behaves the same.
+fn tight<T:Hashable+Stringer>(x: T) { x }
+assert_eq(tight(9), 9)
+
 IO.puts("test_generic_bound OK")

--- a/tests/test_generic_bound.cul
+++ b/tests/test_generic_bound.cul
@@ -1,0 +1,74 @@
+// Generic constraint dispatch: `<T: Bound>` is lowered to its bound
+// trait at declaration time, so the existing trait-conformance
+// machinery enforces it at dispatch / type_check time. An unbounded
+// `T` lowers to "Any" (free-fn generics now work at all). Lenient
+// T-unification: each T-position must conform to the bound, but
+// repeated T is NOT forced to a single concrete type.
+
+// --- Free-fn generics work (regression: previously rejected all args) ---
+fn id<T>(x: T) { x }
+assert_eq(id(5), 5)
+assert_eq(id("hi"), "hi")
+assert_eq(id([1, 2, 3]).size(), 3)   // Array == is identity, so check size
+
+// --- Bound accepts conforming args, rejects non-conforming ---
+fn needs_cmp<T: Comparable>(x: T) { x }
+assert_eq(needs_cmp(5), 5)          // Long is Comparable
+assert_eq(needs_cmp(1.5), 1.5)      // Float is Comparable
+assert_eq(needs_cmp("ab"), "ab")    // String is Comparable
+
+let e_arr = try { needs_cmp([1, 2, 3]); nil } catch e { e }
+assert_eq(e_arr != nil, true)       // Array is not Comparable -> rejected
+
+// --- Overload ordering: concrete > bounded > unbounded ---
+fn rank(x: Long) { "concrete" }
+fn rank<T: Comparable>(x: T) { "bounded" }
+fn rank<T>(x: T) { "unbounded" }
+assert_eq(rank(5), "concrete")       // exact concrete wins
+assert_eq(rank(1.5), "bounded")      // Float conforms to Comparable, not concrete Long
+assert_eq(rank([1]), "unbounded")    // Array conforms to neither -> catch-all
+
+// --- User class conforming to Comparable dispatches to bounded fn ---
+// and trait default methods (gt/lt built on cmp) work in the body.
+class Money {
+  new(amount) { this.amount = amount }
+  cmp(other) { this.amount - other.amount }
+}
+fn pick_max<T: Comparable>(a: T, b: T) { if a.gt(b) { a } else { b } }
+assert_eq(pick_max(Money.new(10), Money.new(25)).amount, 25)
+assert_eq(pick_max(Money.new(40), Money.new(7)).amount, 40)
+
+// A class WITHOUT cmp does not conform -> rejected by the bound.
+class Plain { new(v) { this.v = v } }
+let e_plain = try { needs_cmp(Plain.new(1)); nil } catch e { e }
+assert_eq(e_plain != nil, true)
+
+// --- Lenient T-unification: repeated T is not forced to one type ---
+fn pair_ok<T: Comparable>(a: T, b: T) { (a, b) }
+assert_eq(pair_ok(3, 9), (3, 9))
+assert_eq(pair_ok(1, 2.0), (1, 2.0))     // mixed Long/Float, both Comparable
+assert_eq(pair_ok(1, "x"), (1, "x"))     // mixed Long/String, both Comparable
+let e_one = try { pair_ok([1], 2); nil } catch e { e }
+assert_eq(e_one != nil, true)            // first arg not Comparable -> rejected
+
+// Independent type-params bind independently.
+fn zip2<A, B>(a: A, b: B) { (a, b) }
+assert_eq(zip2(1, "hi"), (1, "hi"))
+
+// --- Introspection preserves the declared type-param name ---
+assert_eq(needs_cmp.params[0].type, "T")
+assert_eq(pick_max.params[0].type, "T")
+
+// --- Bounded class type-param enforces on methods too ---
+class Box<T: Comparable> {
+  new(v) { this.v = v }
+  set(v: T) { this.v = v }
+  get() { this.v }
+}
+let b = Box.new(1)
+b.set(42)
+assert_eq(b.get(), 42)
+let e_box = try { b.set([1, 2]); nil } catch e { e }
+assert_eq(e_box != nil, true)            // Array violates T: Comparable
+
+IO.puts("test_generic_bound OK")

--- a/tests/test_trait_inherit.cul
+++ b/tests/test_trait_inherit.cul
@@ -1,0 +1,68 @@
+// Trait inheritance: `trait Ord: Eq` flattens the supertrait's methods
+// into the subtrait, so conforming to Ord requires Eq's methods too.
+// Works transitively and across all three backends (the AOT path
+// flattens at runtime via culebra_runtime_register_trait_super).
+
+trait Eq { eq(other) -> Bool }
+trait Ord: Eq { cmp(other) -> Long }
+
+// A class with BOTH eq and cmp conforms to Ord.
+class Money {
+  new(a) { this.a = a }
+  eq(other) { this.a == other.a }
+  cmp(other) { this.a - other.a }
+}
+fn needs_ord<T: Ord>(x: T) { x.a }
+assert_eq(needs_ord(Money.new(5)), 5)
+
+// cmp but no eq -> the inherited Eq.eq is missing -> rejected.
+class Partial { new(a) { this.a = a } cmp(other) { this.a - other.a } }
+let e_partial = try { needs_ord(Partial.new(1)); nil } catch ex { ex }
+assert_eq(e_partial != nil, true)
+
+// Transitive: Done: Ord (and Ord: Eq) requires eq + cmp + done.
+trait Done: Ord { done() -> Bool }
+class Task {
+  new() { this.x = 1 }
+  eq(o) { true }
+  cmp(o) { 0 }
+  done() { true }
+}
+fn needs_done<T: Done>(x: T) { x.done() }
+assert_eq(needs_done(Task.new()), true)
+
+// Missing a transitively-required method (eq) -> rejected.
+class Task2 { new() { this.x = 1 } cmp(o) { 0 } done() { true } }
+let e_task2 = try { needs_done(Task2.new()); nil } catch ex { ex }
+assert_eq(e_task2 != nil, true)
+
+// An inherited DEFAULT method is usable on the subtrait.
+trait Greet {
+  name() -> String
+  hello() -> String { "hi {this.name()}" }
+}
+trait LoudGreet: Greet { shout() -> String }
+class Bob { new() { this.x = 1 } name() { "bob" } shout() { "HEY" } }
+fn greet<T: LoudGreet>(x: T) { x.hello() }   // hello inherited from Greet
+assert_eq(greet(Bob.new()), "hi bob")
+
+// Multiple supertraits: Both: Eq, Show requires eq + show.
+trait Show { show() -> String }
+trait Both: Eq, Show { extra() }
+class Widget { new() { this.x = 1 } eq(o) { true } show() { "w" } extra() { 0 } }
+fn use_both<T: Both>(x: T) { x.show() }
+assert_eq(use_both(Widget.new()), "w")
+
+class MissShow { new() { this.x = 1 } eq(o) { true } extra() { 0 } }
+let e_ms = try { use_both(MissShow.new()); nil } catch ex { ex }
+assert_eq(e_ms != nil, true)
+
+// Composite bound interacts with inheritance: <T: Ord + Show>.
+fn ord_and_show<T: Ord + Show>(x: T) { x.show() }
+class Combo {
+  new() { this.x = 1 }
+  eq(o) { true } cmp(o) { 0 } show() { "c" }
+}
+assert_eq(ord_and_show(Combo.new()), "c")
+
+IO.puts("test_trait_inherit OK")


### PR DESCRIPTION
Implements the Generic bound features of the type-system work. Three
independently reviewable commits; all verified across the interp, JIT,
and AOT backends.

1. Generic constraint dispatch `<T: Comparable>` — a bounded type-param
   is lowered to its bound trait at declaration time, reusing the
   existing trait-conformance machinery. Side effect: free-function
   generics (`fn id<T>(x: T)`) now work at all. T-unification is lenient.

2. Composite bound `<T: A + B>` — all-of intersection (the dual of a
   Union's any-of). Spacing-tolerant.

3. Trait inheritance `trait Ord: Eq` — a supertrait's methods are
   flattened into the subtrait (transitive; inherited default methods
   available). New TRAIT_HEAD token kept as a single capture token, so
   no AST-walker impact.

Tests: 80 pass / 0 fail across both backends; new test_generic_bound.cul
and test_trait_inherit.cul. Grammar validated with peglint. Docs synced.

Out of scope: `where` clauses (redundant with inline bounds); primitive
conformance via inherited traits (name-based, structural only).