### PR TITLE
JIT EH: classify caught errors from a pending carrier, not `try { throw; }`

### DIFF
--- a/include/jit.h
+++ b/include/jit.h
@@ -1351,6 +1351,9 @@ inline auto _culebra_hash_at(int64_t line, int64_t col, F&& op)
       e.line = line;
       e.col = col;
     }
+    // Keep the pending carrier (read by the JIT catch pad) in sync with the
+    // position just stamped onto the in-flight exception.
+    culebra::culebra_note_pending_error(e);
     throw;
   }
 }
@@ -1560,6 +1563,7 @@ CULEBRA_RT_KEEP CULEBRA_RT_INLINE int64_t culebra_runtime_hash_any(
       e.line = static_cast<int>(line);
       e.col = static_cast<int>(col);
     }
+    culebra::culebra_note_pending_error(e);
     throw;
   }
 }
@@ -1793,6 +1797,19 @@ CULEBRA_RT_KEEP CULEBRA_RT_INLINE int64_t culebra_runtime_get_thrown_data() {
 // the normal and the swallowed paths: if the cleanup replaced the payload,
 // release the replacement and put the snapshot back (the save's retain
 // transfers into the carrier); otherwise just drop the snapshot's retain.
+// LIFO stack of pending-error snapshots, paired with save/restore below. A
+// runtime error in flight lives only in the pending carrier (is_throw is still
+// 0 until a catch pad materializes it), so a swallowed dispose() that throws its
+// own CulebraError would overwrite it — the pending analogue of the thrown-value
+// clobber the save/restore was written for. The interpreter needs no such thing:
+// its in-flight error is a distinct C++ exception object, untouched by dispose's.
+struct _PendingSnapshot {
+  int8_t error;
+  std::string kind, msg;
+  int64_t line, col;
+};
+inline thread_local std::vector<_PendingSnapshot> _pending_save_stack;
+
 CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_save_thrown(
     int8_t* out_flag, int8_t* out_tag, int64_t* out_data) {
   auto& rt = culebra::current_runtime();
@@ -1800,6 +1817,9 @@ CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_save_thrown(
   *out_tag = rt.thrown_tag;
   *out_data = rt.thrown_data;
   if (rt.is_throw) culebra_runtime_value_retain(rt.thrown_tag, rt.thrown_data);
+  _pending_save_stack.push_back({rt.pending_error, rt.pending_kind,
+                                 rt.pending_msg, rt.pending_line,
+                                 rt.pending_col});
 }
 
 CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_restore_thrown(
@@ -1819,6 +1839,17 @@ CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_restore_thrown(
   rt.thrown_tag = tag;
   rt.thrown_data = data;
   rt.is_throw = flag;
+  // Restore the pending carrier the swallowed cleanup may have overwritten
+  // (paired push in save above; LIFO across nested disposes).
+  if (!_pending_save_stack.empty()) {
+    auto& s = _pending_save_stack.back();
+    rt.pending_error = s.error;
+    rt.pending_kind = std::move(s.kind);
+    rt.pending_msg = std::move(s.msg);
+    rt.pending_line = s.line;
+    rt.pending_col = s.col;
+    _pending_save_stack.pop_back();
+  }
 }
 
 CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_throw(int8_t tag,
@@ -4824,41 +4855,39 @@ CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_object_set_ic(
   if (std::string_view(key) == "drop") _jit_owned_bind_drop(obj);
 }
 
-// Build a structured Error Object for a C++ exception that has reached
-// a try/catch landingpad. Called inside an active __cxa_begin_catch
-// region so `try { throw; }` re-raises the same exception for type
-// inspection. On success, populates the culebra_thrown_* globals as if
-// the user had run `throw error_object` and sets `is_throw=1`. Foreign
-// exceptions (anything we can't classify) leave `is_throw=0` so the
-// caller will propagate them with __cxa_rethrow.
+// Build a structured Error Object for a C++ exception that has reached a
+// try/catch landingpad, from the pending carrier a CulebraError recorded at its
+// construction (see culebra_note_pending_error). This replaces an older
+// `try { throw; } catch` re-inspection, which needed an active __cxa_begin_catch
+// context — a dependency Windows SEH funclet EH can't provide inside a catchpad.
+// On success, populates the thrown-value carriers as if the user had run
+// `throw error_object`. A user `throw` already set `is_throw` with a real Value,
+// so it early-outs. A foreign C++ exception (no pending carrier) leaves
+// `is_throw=0` so the caller propagates it with __cxa_rethrow.
 CULEBRA_RT_KEEP CULEBRA_RT_INLINE void culebra_runtime_try_translate() {
   auto& rt = culebra::current_runtime();
-  if (rt.is_throw) return;
-  auto build = [&rt](std::string_view kind, std::string_view msg,
-                     int64_t line, int64_t col) {
-    auto* obj = culebra_runtime_object_new();
-    culebra_runtime_object_set(
-        obj, "kind", false, TAG_STRING,
-        reinterpret_cast<int64_t>(_culebra_heap_str(kind)), 0, 0);
-    culebra_runtime_object_set(
-        obj, "message", false, TAG_STRING,
-        reinterpret_cast<int64_t>(_culebra_heap_str(msg)), 0, 0);
-    culebra_runtime_object_set(obj, "line", false, TAG_LONG, line, 0, 0);
-    culebra_runtime_object_set(obj, "col", false, TAG_LONG, col, 0, 0);
-    rt.thrown_tag = TAG_OBJECT;
-    rt.thrown_data = reinterpret_cast<int64_t>(obj);
-    rt.is_throw = 1;
-  };
-  try {
-    throw;
-  } catch (culebra::CulebraError& e) {
-    _jit_backfill_op_pos(e);  // positionless runtime error → published op pos
-    build(e.kind, e.what(), e.line, e.col);
-  } catch (const std::runtime_error& e) {
-    build("RuntimeError", e.what(), 0, 0);
-  } catch (...) {
-    // Foreign exception — let the landingpad rethrow it.
+  if (rt.is_throw) return;        // user throw already carries a Value
+  if (!rt.pending_error) return;  // foreign exception — the pad rethrows it
+  // A positionless runtime error (line/col 0) adopts the last published op
+  // position, matching the old _jit_backfill_op_pos path.
+  int64_t line = rt.pending_line, col = rt.pending_col;
+  if (line == 0 && col == 0) {
+    line = _jit_op_line;
+    col = _jit_op_col;
   }
+  auto* obj = culebra_runtime_object_new();
+  culebra_runtime_object_set(
+      obj, "kind", false, TAG_STRING,
+      reinterpret_cast<int64_t>(_culebra_heap_str(rt.pending_kind)), 0, 0);
+  culebra_runtime_object_set(
+      obj, "message", false, TAG_STRING,
+      reinterpret_cast<int64_t>(_culebra_heap_str(rt.pending_msg)), 0, 0);
+  culebra_runtime_object_set(obj, "line", false, TAG_LONG, line, 0, 0);
+  culebra_runtime_object_set(obj, "col", false, TAG_LONG, col, 0, 0);
+  rt.thrown_tag = TAG_OBJECT;
+  rt.thrown_data = reinterpret_cast<int64_t>(obj);
+  rt.is_throw = 1;
+  rt.pending_error = 0;  // consumed
 }
 
 // Write `(tag, data)` to the out-params; nil if entry is null.
@@ -21572,20 +21601,21 @@ struct JIT {
       builder_.CreateBr(endBB);
     }
 
-    // --- Landing pad: catch-all. begin_catch enters the C++ catch
-    // context, then `culebra_runtime_try_translate` inspects the
-    // in-flight exception. If it's a user throw (`culebra_is_throw==1`
-    // already, set by `culebra_runtime_throw`) or a CulebraError /
-    // std::runtime_error from a runtime helper (set by translate),
-    // read the carried tag/data and proceed to the catch body.
-    // Otherwise rethrow so the foreign exception keeps unwinding. ---
+    // --- Landing pad: catch-all. `culebra_runtime_try_translate` classifies
+    // the in-flight exception from the carriers: a user throw
+    // (`culebra_is_throw==1`, set by `culebra_runtime_throw`) or a CulebraError
+    // recorded in the pending carrier at its construction. Either way, read the
+    // carried tag/data and proceed to the catch body; a foreign exception (no
+    // carrier) leaves the flag 0 so we rethrow and keep unwinding. ---
     builder_.SetInsertPoint(lpadBB);
     auto lpadTy = llvm::StructType::get(ptrTy, builder_.getInt32Ty());
     auto lpad = builder_.CreateLandingPad(lpadTy, 1, "exc");
     lpad->addClause(llvm::ConstantPointerNull::get(ptrTy));  // catch-all
 
-    // Enter the C++ catch context. begin_catch must run before
-    // translate so its `try { throw; }` re-raises the active exception.
+    // Enter the C++ catch context so we own the exception — needed for the
+    // __cxa_end_catch that consumes it on the handled path and the __cxa_rethrow
+    // on the foreign path. (translate no longer re-raises it; it reads the
+    // carrier, so begin_catch is only about owning the region now.)
     auto excPtr = builder_.CreateExtractValue(lpad, {0}, "exc.ptr");
     auto beginCatch = module_->getOrInsertFunction(
         "__cxa_begin_catch", ptrTy, ptrTy);

--- a/include/shared.h
+++ b/include/shared.h
@@ -104,6 +104,15 @@ struct sv_equal {
 
 // --- Structured runtime error ---
 
+// Records a just-constructed CulebraError into the current Runtime's pending
+// carrier (defined after Runtime is complete). The JIT try/catch pad reads that
+// carrier instead of re-inspecting the in-flight C++ exception with `throw;` —
+// the portable path for Windows SEH funclet EH. Declared here so the ctor below
+// can call it; a no-op for anything that ignores the carrier (the interpreter).
+inline void culebra_note_pending_error(const std::string& kind,
+                                       const std::string& msg, long line,
+                                       long col);
+
 // Both backends throw this; try/catch machinery translates it into a
 // culebra Object with `kind`/`message`/`line`/`col` fields. Inherits
 // from std::runtime_error so unconverted call sites still work via
@@ -118,8 +127,38 @@ class CulebraError : public std::runtime_error {
       : std::runtime_error(std::move(msg)),
         kind(std::move(k)),
         line(l),
-        col(c) {}
+        col(c) {
+    // Publish this error as the current pending one at construction — which
+    // immediately precedes the throw at every call site — so a JIT catch pad
+    // can materialize it from the carrier without a `throw;` re-inspection.
+    culebra_note_pending_error(kind, what(), line, col);
+  }
+  // Copy/move must publish too: an isolate re-surfaces a producer's stored error
+  // at join() with `throw *stored`, which COPIES — and that copy is what unwinds,
+  // so the JIT catch pad must find it in the carrier exactly as a fresh throw
+  // would. Assignment is plain storage (not a throw), so it stays defaulted.
+  CulebraError(const CulebraError& o)
+      : std::runtime_error(o), kind(o.kind), line(o.line), col(o.col) {
+    culebra_note_pending_error(kind, what(), line, col);
+  }
+  CulebraError(CulebraError&& o)
+      : std::runtime_error(std::move(o)),
+        kind(std::move(o.kind)),
+        line(o.line),
+        col(o.col) {
+    culebra_note_pending_error(kind, what(), line, col);
+  }
+  CulebraError& operator=(const CulebraError&) = default;
+  CulebraError& operator=(CulebraError&&) = default;
 };
+
+// Re-publish an in-flight error into the pending carrier after a backfill catch
+// has adjusted its position (a runtime site that stamps its own line/col onto a
+// positionless error and rethrows). Keeps the carrier the JIT pad reads in sync
+// with the exception object. One place maps a CulebraError to the carrier.
+inline void culebra_note_pending_error(const CulebraError& e) {
+  culebra_note_pending_error(e.kind, e.what(), e.line, e.col);
+}
 
 // Absolute path to the running culebra executable, for re-spawning a worker
 // copy of the interpreter (Sys.executable). macOS: _NSGetExecutablePath;
@@ -1422,6 +1461,26 @@ struct Runtime {
   int64_t thrown_data = 0;
   int8_t is_throw = 0;
 
+  // Pending runtime-error carrier (backend-neutral: kind/msg/line/col, no
+  // Value). Every CulebraError records itself here at construction; the JIT
+  // try/catch pad materializes it into thrown_tag/data rather than re-inspecting
+  // the in-flight C++ exception via `throw;` (which Windows SEH funclet EH can't
+  // do). Distinct from the `is_throw` carriers because a user `throw` fills
+  // those directly (it already has a Value), while a runtime error carries only
+  // text until a catch pad turns it into an error Object. The interpreter
+  // ignores this — it catches the C++ CulebraError directly.
+  //
+  // Invariant: trusted only while a culebra error is unwinding. It is consumed
+  // (cleared) by the catch pad's try_translate, restored across a swallowing
+  // dispose(), and superseded by the next thrown error. A runtime helper that
+  // catches a CulebraError in C++ and RECOVERS (does not rethrow) must clear
+  // pending_error, or a later foreign C++ exception could be misread as it.
+  std::string pending_kind;
+  std::string pending_msg;
+  int64_t pending_line = 0;
+  int64_t pending_col = 0;
+  int8_t pending_error = 0;
+
   // Cooperative cancellation. When non-null and set, the interpreter's
   // statement dispatch throws `Interrupted` to unwind this thread (an isolate
   // being cancelled / dropped). The flag itself lives on the owning IsolateCore
@@ -1461,6 +1520,22 @@ inline Runtime& default_runtime() {
 inline Runtime& current_runtime() {
   return _culebra_current_runtime ? *_culebra_current_runtime
                                   : default_runtime();
+}
+
+// Definition of the forward-declared hook (see CulebraError's ctor). Records the
+// error's text into the current Runtime's pending carrier; cheap and on the cold
+// error path. current_runtime() always returns a valid Runtime (a lazily-created
+// thread-local when none is installed), so this is safe from any context — parse,
+// interpret, or JIT.
+inline void culebra_note_pending_error(const std::string& kind,
+                                       const std::string& msg, long line,
+                                       long col) {
+  auto& rt = current_runtime();
+  rt.pending_kind = kind;
+  rt.pending_msg = msg;
+  rt.pending_line = line;
+  rt.pending_col = col;
+  rt.pending_error = 1;
 }
 
 // True when the current isolate has been asked to cancel (see Runtime::

--- a/include/stdlib_jit.h
+++ b/include/stdlib_jit.h
@@ -6018,6 +6018,7 @@ inline JitValue _jit_ns_method_dispatch(const NsMethod* m, int64_t n_args,
     }
   } catch (culebra::CulebraError& e) {
     if (e.line == 0) { e.line = line; e.col = col; }
+    culebra::culebra_note_pending_error(e);
     throw;
   }
 }
@@ -6179,6 +6180,7 @@ inline bool _jit_ns_kwarg_resolve_core(
       *out = _jit_ns_dispatch_owned_slab(m, slab);
     } catch (culebra::CulebraError& e) {
       if (e.line == 0) { e.line = line; e.col = col; }
+      culebra::culebra_note_pending_error(e);
       throw;
     }
     return true;


### PR DESCRIPTION
Groundwork for the Windows JIT/AOT port. The JIT try/catch landing pad classified an in-flight C++ exception by re-raising it inside an active `__cxa_begin_catch` region (`culebra_runtime_try_translate`'s `try { throw; } catch (CulebraError&)`). That re-inspection depends on the Itanium caught-exception context, which a **Windows SEH funclet `catchpad` cannot provide** — so it blocks the JIT/AOT Windows port. This removes the dependency ahead of that work.

## Approach
A backend-neutral **pending carrier** on the Runtime (`kind`/`msg`/`line`/`col`). Every `CulebraError` records itself there at construction (and at copy/move — an isolate re-surfaces a producer's stored error with `throw *stored`, which copies, and that copy is what unwinds). The catch pad reads the carrier instead of the live exception, keeping the catch-all + no-typeinfo shape the JIT already relies on and dropping `try { throw; }` entirely. The **interpreter is unaffected** — it catches the C++ `CulebraError` directly and ignores the carrier.

## Details
- `Runtime` gains `pending_{kind,msg,line,col,error}`; `CulebraError`'s ctors publish via `culebra_note_pending_error`.
- `culebra_runtime_try_translate` reads the carrier; a user throw (real Value) still early-outs, a foreign exception (no carrier) still rethrows. The old `std::runtime_error` branch is dropped — every such throw is an internal/codegen invariant, never a runtime-catchable error.
- Runtime backfill sites that stamp a position onto a positionless in-flight error and rethrow re-sync the carrier (the difftest corpus pinned these exactly).
- `save`/`restore_thrown` also snapshot/restore the carrier, so a swallowed `dispose()` that throws its own error can't clobber the in-flight one.

Itanium-only in effect (macOS/Linux keep landingpads). **This PR runs the POSIX CI** (macOS + ubuntu GCC) — the change is toolchain-sensitive (copy/move ctors + libstdc++ vs libc++ EH), so both are worth confirming before merge.

## Verification (local, macOS)
Full gate green: 16/16 ctest incl `jit_error_pos_test`, isolate incl `fan_in`, difftest 5434 interp==jit, AOT==JIT, wrap. Two subtle bugs the gate caught during development (position desync on backfill-rethrow; cross-isolate re-throw bypassing the stash via the copy ctor) are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)